### PR TITLE
Fix/tab options remains open

### DIFF
--- a/admin/src/App.jsx
+++ b/admin/src/App.jsx
@@ -9,9 +9,7 @@ import { isKeycloakSupported } from './shared/utils'
 
 import {
    TabBar,
-   Lang,
    RedirectBanner,
-   Sidebar,
    InsightDashboard,
    AddressTunnel,
    Banner,
@@ -142,7 +140,6 @@ const App = () => {
             </Switch>
          </main>
          {/* {!isKeycloakSupported() && <RedirectBanner />} */}
-         <Lang />
          <BottomBar />
       </Layout>
    )

--- a/admin/src/shared/components/Tabs/components/TabOption/index.js
+++ b/admin/src/shared/components/Tabs/components/TabOption/index.js
@@ -4,8 +4,12 @@ import { Styles } from './styled'
 import { useTabs } from '../../../../providers'
 import { CloseIcon } from '../../../../assets/icons'
 
-const TabOption = () => {
+const TabOption = ({ setOpen }) => {
    const { tabs, removeTab, closeAllTabs, switchTab } = useTabs()
+   const handleCloseAllTabs = () => {
+      closeAllTabs()
+      setOpen(false)
+   }
    return (
       <>
          {tabs.length > 0 && (
@@ -33,7 +37,7 @@ const TabOption = () => {
                   <Styles.SmallText>
                      Opened tabs ({tabs.length})
                   </Styles.SmallText>
-                  <div onClick={() => closeAllTabs()}>Close All Tabs</div>
+                  <div onClick={handleCloseAllTabs}>Close All Tabs</div>
                </Styles.CloseTab>
                <Styles.TabContainer>
                   {tabs.map((tab, index) => (

--- a/admin/src/shared/components/Tabs/index.jsx
+++ b/admin/src/shared/components/Tabs/index.jsx
@@ -151,7 +151,7 @@ const Tabs = () => {
                >
                   <ThreeDots color={open ? '#367BF5' : '#45484C'} />
                </StyledButton>
-               {open && <TabOption />}
+               {open && <TabOption setOpen={setOpen} />}
             </div>
          )}
       </TabsWrapper>


### PR DESCRIPTION
- Previously while closing all tabs using close all tabs button. It just closed all the tabs. Hence the tab options panel show up again after changing the route. 
- Language moved to the Options, so removed it from home. 

After merging this, this problem won't occur. 