### PR TITLE
fix: linked components not showing in page form

### DIFF
--- a/admin/src/apps/content/graphql/subscription/index.js
+++ b/admin/src/apps/content/graphql/subscription/index.js
@@ -165,21 +165,22 @@ export const GET_TEMPLATES = gql`
 `
 
 export const LINKED_COMPONENT = gql`
-   subscription NAVIGATION_MENU_INFO($menuId: Int!) {
-      website_navigationMenuItem(
-         where: { navigationMenuId: { _eq: $menuId } }
+   subscription LINKED_COMPONENT($pageId: Int!) {
+      website_websitePageModule(
+         where: { websitePageId: { _eq: $pageId } }
          order_by: { position: desc_nulls_last }
       ) {
+         fileId
          id
-         label
-         navigationMenuId
-         openInNewTab
-         parentNavigationMenuItemId
+         config
+         internalModuleIdentifier
+         moduleType
          position
-         url
-         navigationMenu {
-            isPublished
-            title
+         templateId
+         visibilityConditionId
+         file {
+            fileName
+            path
          }
       }
    }

--- a/admin/src/apps/content/views/Forms/Page/ContentSelection/index.js
+++ b/admin/src/apps/content/views/Forms/Page/ContentSelection/index.js
@@ -85,7 +85,7 @@ const ContentSelection = () => {
          closeConfigTunnel(1)
       },
       onError: error => {
-         toast.error('Something went wrong')
+         toast.error('Something went wrong while updating link component')
          logger(error)
          closeConfigTunnel(1)
       },
@@ -98,7 +98,7 @@ const ContentSelection = () => {
          setSelectedFileOptions([])
       },
       onError: error => {
-         toast.error('Something went wrong')
+         toast.error('Something went wrong while deleting linked component')
          logger(error)
          setSelectedFileOptions([])
       },
@@ -125,7 +125,7 @@ const ContentSelection = () => {
          const result = selectedFileOptions.map(option => {
             return {
                websitePageId: +pageId,
-               moduleType: option.type==="html"?'block':'file',
+               moduleType: option.type === 'html' ? 'block' : 'file',
                fileId: option.id,
             }
          })
@@ -168,7 +168,10 @@ const ContentSelection = () => {
       return <InlineLoader />
    }
    if (subscriptionError) {
-      toast.error('Something went wrong')
+      console.log(subscriptionError)
+      toast.error(
+         'Something went wrong in subscription query for linked components'
+      )
       logger(subscriptionError)
    }
    return (

--- a/admin/src/apps/content/views/Forms/Page/index.js
+++ b/admin/src/apps/content/views/Forms/Page/index.js
@@ -29,7 +29,7 @@ import { PagePreviewTunnel } from './Tunnel'
 
 const PageForm = () => {
    const [tunnels, openTunnel, closeTunnel] = useTunnel()
-   const { addTab, tab, setTitle: setTabTitle, closeAllTabs } = useTabs()
+   const { addTab, tab, setTabTitle, closeAllTabs } = useTabs()
    const [context, setContext] = useContext(BrandContext)
    const prevBrandId = useRef(context.brandId)
    const { pageId, pageName } = useParams()
@@ -106,10 +106,10 @@ const PageForm = () => {
    const [updatePage] = useMutation(UPDATE_WEBPAGE, {
       onCompleted: () => {
          toast.success('Updated!')
-         setTabTitle(pageTitle.value)
       },
       onError: error => {
-         toast.error('Something went wrong')
+         toast.error('Something went wrong with update_webpage')
+         console.log(error)
          logger(error)
       },
    })
@@ -129,22 +129,19 @@ const PageForm = () => {
       })
       // }
    }
-   // const updateCheckbox = () => {
-   //    updatePage({
-   //       variables: {
-   //          id: couponId,
-   //          set: {
-   //             isRewardMulti: !checkbox,
-   //          },
-   //       },
-   //    })
-   // }
 
    useEffect(() => {
       if (!tab) {
          addTab('Pages', '/content/pages')
       }
    }, [addTab, tab])
+
+   // whenever pageTitle value changes the tab title will be updated also
+   useEffect(() => {
+      if (pageTitle.value && !Boolean(pageTitle.meta.errors.length)) {
+         setTabTitle(pageTitle.value)
+      }
+   }, [pageTitle])
 
    if (context.brandId !== prevBrandId.current) {
       closeAllTabs()


### PR DESCRIPTION
### Description
- Refactor linked components query used in the page form
- Fixed the error of linked components not showing while opening page form in the content app

### Previous behavious
- Page form in the content app doesn't show linked component and gives toast error

### New behaviour
- Page form in the content app doesn't give error and shows all the  linked component to that page

