### PR TITLE
style: updated some styling issue in page form

### DIFF
--- a/admin/src/apps/content/views/Forms/Page/ContentSelection/File/index.js
+++ b/admin/src/apps/content/views/Forms/Page/ContentSelection/File/index.js
@@ -104,4 +104,18 @@ const File = ({ linkedFiles, selectedOption, emptyOptions }) => {
 }
 export default File
 
-export const Wrapper = styled.div``
+export const Wrapper = styled.div`
+   width: 100%;
+   li {
+      margin-bottom: 8px;
+      div {
+         width: 100%;
+         h3 {
+            margin: 0;
+         }
+         p {
+            margin: 0;
+         }
+      }
+   }
+`

--- a/admin/src/apps/content/views/Forms/Page/ContentSelection/index.js
+++ b/admin/src/apps/content/views/Forms/Page/ContentSelection/index.js
@@ -66,17 +66,20 @@ const ContentSelection = () => {
    )
 
    // Create mutation
-   const [linkComponent] = useMutation(LINK_COMPONENT, {
-      onCompleted: () => {
-         toast.success(`Added to the "${pageName}" page successfully!!`)
-         setSelectedFileOptions([])
-      },
-      onError: error => {
-         toast.error('Something went wrong')
-         logger(error)
-         setSelectedFileOptions([])
-      },
-   })
+   const [linkComponent, { loading: isLinkingComponent }] = useMutation(
+      LINK_COMPONENT,
+      {
+         onCompleted: () => {
+            toast.success(`Added to the "${pageName}" page successfully!!`)
+            setSelectedFileOptions([])
+         },
+         onError: error => {
+            toast.error('Something went wrong')
+            logger(error)
+            setSelectedFileOptions([])
+         },
+      }
+   )
 
    // Update mutation
    const [updateLinkComponent] = useMutation(UPDATE_LINK_COMPONENT, {
@@ -219,7 +222,12 @@ const ContentSelection = () => {
          </WrapDiv>
          <StyledWrapper>
             <Flex container justifyContent="flex-end">
-               <ComboButton type="solid" size="md" onClick={saveHandler}>
+               <ComboButton
+                  type="solid"
+                  size="md"
+                  isLoading={isLinkingComponent}
+                  onClick={saveHandler}
+               >
                   <PlusIcon color="#fff" /> Add
                </ComboButton>
             </Flex>

--- a/admin/src/apps/content/views/Forms/Page/styled.js
+++ b/admin/src/apps/content/views/Forms/Page/styled.js
@@ -52,6 +52,7 @@ export const StyledDiv = styled.div`
 export const Highlight = styled.p`
    color: #00a7e1;
    cursor: pointer;
+   margin: 0;
    &:hover {
       text-decoration: underline;
    }


### PR DESCRIPTION
### Description

- Updated styling in page form in content app.
- Added loading status in Add button when files are added
- Fixed alignment issue

### Previous behaviour

- Page form in the content app show list of files in misaligned way, can't distinguish two different files
- Page form in the content app has alignment issue 

### New behaviour

- Page form in the content app show list of files in better way without alignment issue