### PR TITLE
fix: close add product tunnel in collections

### DIFF
--- a/admin/src/apps/menu/views/Forms/Collection/tunnels/Products/index.js
+++ b/admin/src/apps/menu/views/Forms/Collection/tunnels/Products/index.js
@@ -106,7 +106,7 @@ const ProductsTunnel = ({ categoryId, closeTunnel }) => {
                address.concat('select and add products to the collection')
             )}
             right={{ action: save, title: inFlight ? 'Adding...' : 'Add' }}
-            close={() => closeTunnel(2)}
+            close={() => closeTunnel(1)}
             tooltip={<Tooltip identifier="collections_products_tunnel" />}
          />
          <Banner id="menu-app-collections-collection-details-collections-products-tunnel-top" />{' '}


### PR DESCRIPTION
1. Fix not closing of add product tunnel in collections in menu app