### PR TITLE
fix: input form zoom on iphone

### DIFF
--- a/store/src/styles/globals.css
+++ b/store/src/styles/globals.css
@@ -259,3 +259,13 @@ code {
       height: 1.4em;
    }
 }
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+   select,
+   textarea,
+   input,
+   select:focus,
+   textarea:focus,
+   input:focus {
+      font-size: 16px !important;
+   }
+}


### PR DESCRIPTION
On iPhone and similar pixel, ratio's devices zoom in the form of the font size is less than 16px. 
In this PR a global font size has been set to prevent that. 

This will resolve, 
#516 