### PR TITLE
Feat/login wrapper desktop view

### DIFF
--- a/store/src/assets/icons/Checkbox.js
+++ b/store/src/assets/icons/Checkbox.js
@@ -3,7 +3,7 @@ import React from 'react'
 export const CheckBoxIcon = ({
    size = 15,
    showTick = false,
-   stroke = '#367BF5',
+   stroke = 'var(--hern-accent)',
    ...props
 }) => {
    return (

--- a/store/src/assets/icons/index.js
+++ b/store/src/assets/icons/index.js
@@ -31,16 +31,16 @@ const CheckIcon = dynamic(() =>
    import('./Close').then(promise => promise.CheckIcon)
 )
 const CheckBoxIcon = dynamic(() =>
-   import('./CouponIcon').then(promise => promise.CheckBoxIcon)
+   import('./Checkbox').then(promise => promise.CheckBoxIcon)
 )
 const ChefIcon = dynamic(() =>
-   import('./ArrowLeft').then(promise => promise.ChefIcon)
+   import('./Chef').then(promise => promise.ChefIcon)
 )
 const CloseIcon = dynamic(() =>
-   import('./ArrowLeft').then(promise => promise.CloseIcon)
+   import('./Close').then(promise => promise.CloseIcon)
 )
 const CouponIcon = dynamic(() =>
-   import('./ArrowLeft').then(promise => promise.CouponIcon)
+   import('./CouponIcon').then(promise => promise.CouponIcon)
 )
 const CouponTicketIcon = dynamic(() =>
    import('./CouponTicketIcon').then(promise => promise.CouponTicketIcon)

--- a/store/src/components/login.jsx
+++ b/store/src/components/login.jsx
@@ -141,6 +141,7 @@ export const Login = props => {
                   <div style={{ margin: '1em' }}>
                      <Button
                         className="hern-login-login-switcher-btn"
+                        variant="outline"
                         onClick={() => {
                            defaultLogin === 'email'
                               ? setDefaultLogin('otp')

--- a/store/src/components/login.jsx
+++ b/store/src/components/login.jsx
@@ -72,109 +72,105 @@ export const Login = props => {
    const [defaultLogin, setDefaultLogin] = useState(loginBy)
 
    return (
-      <div className={`hern-login-v1-container`}>
-         <div className="hern-login-v1-content">
-            <div className="hern-login-v1-header">
-               {(defaultLogin === 'email' || defaultLogin === 'otp') && (
-                  <span>Log in</span>
-               )}
-
-               {defaultLogin === 'forgotPassword' && (
-                  <span>Forgot Password</span>
-               )}
-               {defaultLogin === 'signup' && <span>Sign Up</span>}
-
-               {!forceLogin && (
-                  <CloseIcon
-                     size={18}
-                     stroke={'#404040'}
-                     style={{ cursor: 'pointer' }}
-                     onClick={closeLoginPopup}
-                  />
-               )}
-            </div>
-            {forceLogin && (
-               <div className="hern-login-v1__custom-warning">
-                  You must login first to access this page.
-                  <span
-                     onClick={() => {
-                        if (isClient) {
-                           window.location.href =
-                              get_env('BASE_BRAND_URL') + getRoute('/')
-                        }
-                     }}
-                  >
-                     Go To Home
-                  </span>
-               </div>
+      <div className="hern-login-v1-content">
+         <div className="hern-login-v1-header">
+            {(defaultLogin === 'email' || defaultLogin === 'otp') && (
+               <span>Log in</span>
             )}
-            <section>
-               {/* email login  or phone number login*/}
-               {defaultLogin === 'email' && (
-                  <Email
-                     setDefaultLogin={setDefaultLogin}
-                     isSilentlyLogin={isSilentlyLogin}
-                     closeLoginPopup={closeLoginPopup}
-                     callbackURL={callbackURL}
-                  />
-               )}
-               {defaultLogin === 'otp' && (
-                  <OTPLogin
-                     closeLoginPopup={closeLoginPopup}
-                     isSilentlyLogin={isSilentlyLogin}
-                     callbackURL={callbackURL}
-                  />
-               )}
-               {defaultLogin === 'forgotPassword' && (
-                  <ForgotPassword closeLoginPopup={closeLoginPopup} />
-               )}
-               {defaultLogin === 'signup' && (
-                  <Signup
-                     setDefaultLogin={setDefaultLogin}
-                     isSilentlyLogin={isSilentlyLogin}
-                     closeLoginPopup={closeLoginPopup}
-                     callbackURL={callbackURL}
-                  />
-               )}
-               {/* {defaultLogin === 'email' ? <Email /> : <OTPLogin />} */}
 
-               {!singleLoginMethod && (
-                  <>
-                     <DividerBar />
-                     <div style={{ margin: '1em' }}>
-                        <Button
-                           className="hern-login-login-switcher-btn"
-                           onClick={() => {
-                              defaultLogin === 'email'
-                                 ? setDefaultLogin('otp')
-                                 : setDefaultLogin('email')
-                           }}
-                        >
-                           {defaultLogin === 'email'
-                              ? 'Log in with Phone Number'
-                              : 'Log in with Email'}
-                        </Button>
-                     </div>
-                  </>
-               )}
+            {defaultLogin === 'forgotPassword' && <span>Forgot Password</span>}
+            {defaultLogin === 'signup' && <span>Sign Up</span>}
 
-               {/* google or facebook */}
-               {socialLogin && <SocialLogin callbackURL={callbackURL} />}
-            </section>
-            {defaultLogin !== 'signup' && (
-               <footer className="hern-login-v1__footer">
-                  <span>No account? </span>{' '}
-                  <button
-                     className="hern-login-v1__create-one-btn"
-                     onClick={() => {
-                        setDefaultLogin('signup')
-                     }}
-                  >
-                     Create one
-                  </button>
-               </footer>
+            {!forceLogin && (
+               <CloseIcon
+                  size={18}
+                  stroke={'#404040'}
+                  style={{ cursor: 'pointer' }}
+                  onClick={closeLoginPopup}
+               />
             )}
          </div>
+         {forceLogin && (
+            <div className="hern-login-v1__custom-warning">
+               You must login first to access this page.
+               <span
+                  onClick={() => {
+                     if (isClient) {
+                        window.location.href =
+                           get_env('BASE_BRAND_URL') + getRoute('/')
+                     }
+                  }}
+               >
+                  Go To Home
+               </span>
+            </div>
+         )}
+         <section>
+            {/* email login  or phone number login*/}
+            {defaultLogin === 'email' && (
+               <Email
+                  setDefaultLogin={setDefaultLogin}
+                  isSilentlyLogin={isSilentlyLogin}
+                  closeLoginPopup={closeLoginPopup}
+                  callbackURL={callbackURL}
+               />
+            )}
+            {defaultLogin === 'otp' && (
+               <OTPLogin
+                  closeLoginPopup={closeLoginPopup}
+                  isSilentlyLogin={isSilentlyLogin}
+                  callbackURL={callbackURL}
+               />
+            )}
+            {defaultLogin === 'forgotPassword' && (
+               <ForgotPassword closeLoginPopup={closeLoginPopup} />
+            )}
+            {defaultLogin === 'signup' && (
+               <Signup
+                  setDefaultLogin={setDefaultLogin}
+                  isSilentlyLogin={isSilentlyLogin}
+                  closeLoginPopup={closeLoginPopup}
+                  callbackURL={callbackURL}
+               />
+            )}
+            {/* {defaultLogin === 'email' ? <Email /> : <OTPLogin />} */}
+
+            {!singleLoginMethod && (
+               <>
+                  <DividerBar />
+                  <div style={{ margin: '1em' }}>
+                     <Button
+                        className="hern-login-login-switcher-btn"
+                        onClick={() => {
+                           defaultLogin === 'email'
+                              ? setDefaultLogin('otp')
+                              : setDefaultLogin('email')
+                        }}
+                     >
+                        {defaultLogin === 'email'
+                           ? 'Log in with Phone Number'
+                           : 'Log in with Email'}
+                     </Button>
+                  </div>
+               </>
+            )}
+
+            {/* google or facebook */}
+            {socialLogin && <SocialLogin callbackURL={callbackURL} />}
+         </section>
+         {defaultLogin !== 'signup' && (
+            <footer className="hern-login-v1__footer">
+               <span>No account? </span>{' '}
+               <button
+                  className="hern-login-v1__create-one-btn"
+                  onClick={() => {
+                     setDefaultLogin('signup')
+                  }}
+               >
+                  Create one
+               </button>
+            </footer>
+         )}
       </div>
    )
 }

--- a/store/src/styles/components/login_v1.scss
+++ b/store/src/styles/components/login_v1.scss
@@ -65,7 +65,7 @@
    margin: 1em;
    padding: 1em 0.5em;
    span {
-      color: #367bf5;
+      color: var(--hern-accent);
       cursor: pointer;
    }
 }
@@ -85,12 +85,13 @@
 
 .hern-login-v1__input {
    height: 40px;
-   background: #f4f4f4;
+   background: #38a1691a;
    border-radius: 8px;
    padding: 0 10px;
    outline: none;
    &:focus {
-      outline: 1px solid #367bf5;
+      background: #38a1691a;
+      outline: 1px solid var(--hern-accent);
    }
 }
 
@@ -115,7 +116,7 @@
    font-weight: 600;
    font-size: 14px;
    line-height: 18px;
-   color: #367bf5;
+   color: var(--hern-accent);
    cursor: pointer;
 }
 
@@ -132,7 +133,7 @@
    margin-top: 2.5em;
    width: 100%;
    border-radius: 20px;
-   background-color: #367bf5 !important;
+   // background-color: var(--hern-accent) !important;
    transform: none !important;
    box-shadow: none !important;
    color: '#ffffff' !important;
@@ -141,9 +142,10 @@
 }
 
 .hern-login-v1__login-btn--disabled {
-   background: #367bf580 !important;
+   background: var(--hern-accent) !important;
    cursor: not-allowed;
    color: '#ffffff' !important;
+   opacity: 0.5;
 }
 
 .hern-login-v1-divider-bar {
@@ -155,17 +157,17 @@
       font-weight: 600;
       font-size: 18px;
       line-height: 18px;
-      color: rgba(64, 64, 64, 0.25);
+      color: var(--hern-accent);
    }
 }
 
 .hern-login-login-switcher-btn {
    width: 100%;
    background: #ffffff !important;
-   border: 1px solid #367bf5 !important;
+   border: 1px solid var(--hern-accent) !important;
    box-sizing: border-box;
    border-radius: 20px;
-   color: #367bf5;
+   // color: var(--hern-accent);
    height: 40px;
 }
 
@@ -177,13 +179,14 @@
    margin-top: 1.5em;
    border-radius: 20px !important;
    width: 100%;
-   background-color: #367bf5 !important;
+   background-color: var(--hern-accent) !important;
    color: #ffffff !important;
 }
 
 .hern-login-v1__otp-submit--disabled {
-   background-color: #367bf580 !important;
+   background-color: var(--hern-accent) !important;
    cursor: not-allowed;
+   opacity: 0.5;
 }
 
 .hern-login-v1__otp__phone__input {
@@ -194,7 +197,7 @@
       padding: 0 10px;
       outline: none;
       &:focus {
-         outline: 1px solid #367bf5;
+         outline: 1px solid var(--hern-accent);
       }
    }
 }
@@ -230,17 +233,18 @@
    width: 100%;
    height: 2.5rem;
    // text-transform: uppercase;
-   color: #367bf5;
+   color: var(--hern-accent);
    // letter-spacing: 0.05em;
    border-radius: 20px;
    outline: none !important;
    &:hover {
-      border: 1px solid #367bf5 !important;
+      border: 1px solid var(--hern-accent) !important;
    }
 }
 
 .hern-login-v1__otp__resend--disabled {
    cursor: not-allowed;
+   opacity: 0.5;
    &:hover {
       background: #fff;
    }
@@ -261,7 +265,7 @@
    }
 }
 .hern-login-v1__create-one-btn {
-   color: #367bf5;
+   color: var(--hern-accent);
    outline: none !important;
    background: transparent;
    font-size: 14px;
@@ -279,15 +283,16 @@
    margin-top: 2.5em;
    width: 100%;
    border-radius: 20px;
-   background-color: #367bf5 !important;
+   background-color: var(--hern-accent) !important;
    transform: none !important;
    box-shadow: none !important;
    color: #ffffff;
    height: 40px;
 }
 .hern-forgot-password-v1__submit-btn--disabled {
-   background: #367bf580 !important;
+   background: var(--hern-accent) !important;
    cursor: not-allowed;
+   opacity: 0.5;
 }
 
 .hern-signup-v1 {
@@ -316,7 +321,7 @@
 .hern-signup__referral-code {
    align-self: flex-start;
    margin-bottom: 0.25rem;
-   color: #367bf5;
+   color: var(--hern-accent);
 }
 
 .hern-signup-v1__signup__term {
@@ -330,11 +335,11 @@
 }
 
 .hern-signup__signup__term__link {
-   color: #367bf5;
+   color: var(--hern-accent);
 }
 
 .hern-signup-v1__referral-code {
-   color: #367bf5;
+   color: var(--hern-accent);
    cursor: pointer;
    outline: none !important;
 }
@@ -345,12 +350,13 @@
    color: #ffffff;
    height: 40px;
    outline: none !important;
-   background-color: #367bf5 !important;
+   background-color: var(--hern-accent) !important;
 }
 
 .hern-signup-v1__signup__submit--disabled {
-   background: #367bf580 !important;
+   background: var(--hern-accent) !important;
    cursor: not-allowed;
+   opacity: 0.5;
 }
 
 .hern-signup-v1__signup__email-already-exits {
@@ -361,7 +367,7 @@
 .hern-signup-v1__signup__login-switch {
    align-self: flex-start;
    margin-top: 0.5rem;
-   color: #367bf5;
+   color: var(--hern-accent);
    outline: none !important;
 }
 

--- a/store/src/styles/components/login_v1.scss
+++ b/store/src/styles/components/login_v1.scss
@@ -10,6 +10,15 @@
    background-color: #ffffff;
    transition: all 0.4s ease-in-out;
 }
+.hern-login-v1-container__img {
+   display: none;
+   height: 400px;
+   width: auto;
+   > img {
+      height: 100%;
+      width: 100%;
+   }
+}
 .hern-login-v1__css-transition-enter {
    height: 0;
 
@@ -407,14 +416,23 @@
 }
 
 @media only screen and (min-width: 769px) {
+   .hern-login-v1-container__img {
+      display: block;
+   }
    .hern-login-v1-container {
       background-color: rgb(251, 252, 246);
       display: flex;
       justify-content: center;
+      align-items: center;
+      gap: 96px;
+      padding: 16px;
    }
    .hern-login-v1-content {
-      padding: 0;
-      width: 28em;
-      background-color: #ffffff;
+      padding: 20px;
+      max-width: 460px;
+      height: auto;
+      background: #ffffff;
+      box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.15);
+      border-radius: 12px;
    }
 }

--- a/store/src/utils/loginWrapper.js
+++ b/store/src/utils/loginWrapper.js
@@ -16,10 +16,18 @@ export const LoginWrapper = ({ ...props }) => {
          unmountOnExit
          classNames="hern-login-v1__css-transition"
       >
-         <Login
-            {...props}
-            socialLogin={authConfig.socialLoginMethods?.socialLogin?.value}
-         />
+         <div className="hern-login-v1-container">
+            <div className="hern-login-v1-container__img">
+               <img
+                  src="https://dailykit-133-test.s3.us-east-2.amazonaws.com/misc/07680-user%20login.svg"
+                  alt="Login"
+               />
+            </div>
+            <Login
+               {...props}
+               socialLogin={authConfig.socialLoginMethods?.socialLogin?.value}
+            />
+         </div>
       </CSSTransition>
    )
 }

--- a/store/src/utils/loginWrapper.js
+++ b/store/src/utils/loginWrapper.js
@@ -6,17 +6,20 @@ import { useConfig } from '../lib'
 export const LoginWrapper = ({ ...props }) => {
    const { showLoginPopup } = props
 
-   const { configOf, isConfigLoading } = useConfig()
+   const { configOf } = useConfig()
    const authConfig = configOf('Auth Methods', 'brand')
 
+   /** Brand level config for login illustration **/
    const loginIllustration = configOf('Login Illustrations', 'brand')
    const illustration =
-      loginIllustration?.['Login Illustration']?.illustrationImage?.value ||
-      'https://dailykit-133-test.s3.us-east-2.amazonaws.com/images/16322-user_login.png'
-   const showIllustration =
-      loginIllustration?.['Login Illustration']?.showLoginIllustration?.value ||
-      false
+      loginIllustration?.['Login Illustration']?.illustrationImage?.value ??
+      'https://dailykit-133-test.s3.us-east-2.amazonaws.com/images/16322-user_login.png' //fallback Image
 
+   const showIllustration =
+      loginIllustration?.['Login Illustration']?.showLoginIllustration?.value ??
+      false //false as fallback value
+
+   /**Hide or show scrollbar based on loginPopup open or close  */
    React.useEffect(() => {
       if (showLoginPopup) {
          document.querySelector('body').style.overflowY = 'hidden'
@@ -25,6 +28,7 @@ export const LoginWrapper = ({ ...props }) => {
          document.querySelector('body').style.overflowY = 'auto'
       }
    }, [showLoginPopup])
+
    return (
       <CSSTransition
          in={showLoginPopup}
@@ -33,11 +37,13 @@ export const LoginWrapper = ({ ...props }) => {
          classNames="hern-login-v1__css-transition"
       >
          <div className="hern-login-v1-container">
+            {/**Illustration image */}
             {showIllustration && (
                <div className="hern-login-v1-container__img">
                   <img src={illustration} alt="Login" />
                </div>
             )}
+            {/**Login Component */}
             <Login
                {...props}
                socialLogin={authConfig.socialLoginMethods?.socialLogin?.value}

--- a/store/src/utils/loginWrapper.js
+++ b/store/src/utils/loginWrapper.js
@@ -9,6 +9,14 @@ export const LoginWrapper = ({ ...props }) => {
    const { configOf, isConfigLoading } = useConfig()
    const authConfig = configOf('Auth Methods', 'brand')
 
+   React.useEffect(() => {
+      if (showLoginPopup) {
+         document.querySelector('body').style.overflowY = 'hidden'
+      }
+      return () => {
+         document.querySelector('body').style.overflowY = 'auto'
+      }
+   }, [showLoginPopup])
    return (
       <CSSTransition
          in={showLoginPopup}

--- a/store/src/utils/loginWrapper.js
+++ b/store/src/utils/loginWrapper.js
@@ -9,6 +9,14 @@ export const LoginWrapper = ({ ...props }) => {
    const { configOf, isConfigLoading } = useConfig()
    const authConfig = configOf('Auth Methods', 'brand')
 
+   const loginIllustration = configOf('Login Illustrations', 'brand')
+   const illustration =
+      loginIllustration?.['Login Illustration']?.illustrationImage?.value ||
+      'https://dailykit-133-test.s3.us-east-2.amazonaws.com/images/16322-user_login.png'
+   const showIllustration =
+      loginIllustration?.['Login Illustration']?.showLoginIllustration?.value ||
+      false
+
    React.useEffect(() => {
       if (showLoginPopup) {
          document.querySelector('body').style.overflowY = 'hidden'
@@ -25,12 +33,11 @@ export const LoginWrapper = ({ ...props }) => {
          classNames="hern-login-v1__css-transition"
       >
          <div className="hern-login-v1-container">
-            <div className="hern-login-v1-container__img">
-               <img
-                  src="https://dailykit-133-test.s3.us-east-2.amazonaws.com/misc/07680-user%20login.svg"
-                  alt="Login"
-               />
-            </div>
+            {showIllustration && (
+               <div className="hern-login-v1-container__img">
+                  <img src={illustration} alt="Login" />
+               </div>
+            )}
             <Login
                {...props}
                socialLogin={authConfig.socialLoginMethods?.socialLogin?.value}


### PR DESCRIPTION
On the right side, the illustration is config-based. 
- We can show the illustration from the backend or hide it
- We can also change the whole illustration 

**Responsiveness**
- Full desktop view
 
![image](https://user-images.githubusercontent.com/43314398/157662840-c7d2ea4f-313a-429d-ba3d-715602a909e5.png)

- iPad
![image](https://user-images.githubusercontent.com/43314398/157663918-818dd3e8-cc93-45ef-921e-a3b5d28614d9.png)

- iPad Pro

![image](https://user-images.githubusercontent.com/43314398/157664059-893b6b53-1d9b-462c-9fa6-42a73cbbe7b0.png)

- iPhone 5/SE

![image](https://user-images.githubusercontent.com/43314398/157663459-853c7dd5-0305-4ae9-bd9d-678a041eb84a.png)

- Samsung Galaxy S8

![image](https://user-images.githubusercontent.com/43314398/157664288-7f6c0189-2b99-4741-9b14-663b9c9aff63.png)


Designed from : [Figma](https://www.figma.com/file/H50HuMohAuhDvLMn4tSelq/On-demand-store?node-id=1910%3A192)
This will close  #516 