### PR TITLE
fix: showing view recipe when no recipe available in product option

### DIFF
--- a/store/src/components/modifier_popup.jsx
+++ b/store/src/components/modifier_popup.jsx
@@ -579,6 +579,9 @@ export const ModifierPopup = props => {
                         {productOptionsGroupedByProductOptionType
                            .find(eachType => eachType.type == productOptionType)
                            .data.map(eachOption => {
+                              const hasRecipe =
+                                 eachOption?.simpleRecipeYield?.simpleRecipe
+
                               return (
                                  <div
                                     key={eachOption.id}
@@ -613,14 +616,14 @@ export const ModifierPopup = props => {
                                        )}
                                        {')'}
                                     </li>
-                                    {recipeButton.show && (
+                                    {recipeButton.show && hasRecipe && (
                                        <div>
                                           <Link
                                              href={getRoute(
                                                 '/recipes/' + eachOption.id
                                              )}
                                           >
-                                             <>{recipeButton.label}</>
+                                             <a>{recipeButton.label}</a>
                                           </Link>
                                        </div>
                                     )}


### PR DESCRIPTION
- View recipe button will be showing only when there will be a recipe for a particular productOption and from the config view recipe is turned on. 

![image](https://user-images.githubusercontent.com/43314398/157831567-4b8026ba-2ae1-46a5-93c7-fc2bd54af4d7.png)

This will resolve, 
#331