### PR TITLE
fix: fixed error while closing create collection and coupon tunnels

### DIFF
--- a/admin/src/apps/crm/views/Listings/CouponListing/index.js
+++ b/admin/src/apps/crm/views/Listings/CouponListing/index.js
@@ -306,7 +306,7 @@ const CouponListing = () => {
          <Banner id="crm-app-coupons-listing-top" />
          <Tunnels tunnels={couponTunnels}>
             <Tunnel layer={1} size="md">
-               <CreateCoupon close={closeCouponTunnel} />
+               <CreateCoupon closeTunnel={closeCouponTunnel} />
             </Tunnel>
          </Tunnels>
          <Flex

--- a/admin/src/apps/menu/views/Listings/CollectionsListing/index.js
+++ b/admin/src/apps/menu/views/Listings/CollectionsListing/index.js
@@ -151,7 +151,7 @@ const CollectionsListing = () => {
          <Banner id="menu-app-collections-listing-top" />
          <Tunnels tunnels={collectionTunnels}>
             <Tunnel layer={1} size="md">
-               <CreateCollection close={closeCollectionTunnel} />
+               <CreateCollection closeTunnel={closeCollectionTunnel} />
             </Tunnel>
          </Tunnels>
          <Flex

--- a/admin/src/shared/CreateUtils/Menu/createCollection.js
+++ b/admin/src/shared/CreateUtils/Menu/createCollection.js
@@ -57,7 +57,7 @@ const CreateCollection = ({ closeTunnel }) => {
             },
          ])
          toast.success('Successfully created the Collection!')
-         closeTunnel(17)
+         closeTunnel(1)
       },
       onError: () =>
          toast.success('Failed to create the Collection, please try again!'),
@@ -96,7 +96,6 @@ const CreateCollection = ({ closeTunnel }) => {
          console.log('Collection Name::::', collection)
       }
    }
-   console.log('collection :>> ', collection)
 
    // const onBlur = (e, i) => {
    //    const { name, value } = e.target
@@ -157,7 +156,7 @@ const CreateCollection = ({ closeTunnel }) => {
             },
          },
       ])
-      closeTunnel(17)
+      closeTunnel(1)
    }
    return (
       <>

--- a/admin/src/shared/CreateUtils/crm/createCoupon.js
+++ b/admin/src/shared/CreateUtils/crm/createCoupon.js
@@ -47,7 +47,7 @@ const CreateCoupon = ({ closeTunnel }) => {
             },
          ])
          toast.success('Successfully created the Coupon!')
-         closeTunnel(15)
+         closeTunnel(1)
       },
       onError: () =>
          toast.success('Failed to create the Coupon, please try again!'),
@@ -147,7 +147,7 @@ const CreateCoupon = ({ closeTunnel }) => {
             },
          },
       ])
-      closeTunnel(15)
+      closeTunnel(1)
    }
    return (
       <>


### PR DESCRIPTION
## Description
- fixed error which comes when we try to close `create collection` and `create coupons` tunnels.
- Cause for this bug was the wrong naming of `closeTunnel` prop and wrong arguments in it

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- Description of changes and all fixes in this issue

## Screenshots 
(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [x] Looks good on Tablets

Affected Apps
- [ ] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [x] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [x] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
