### PR TITLE
fix: save button in refine location for desktop view

### DIFF
--- a/store/src/styles/components/refineLocation.scss
+++ b/store/src/styles/components/refineLocation.scss
@@ -34,7 +34,10 @@
    margin-top: 4px;
    // height: 26.5rem;
    overflow: auto;
-   // height: 220px;
+   height: 220px;
+   @media (max-width: 480px) {
+      height: unset;
+   }
 }
 .hern-refine-location__address-form-field {
    width: 100%;


### PR DESCRIPTION
## Description
Save and proceed button is not visible in refine location popup desktop view.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- change the css of save and proceed button in refine location for desktop view 

## Screenshots 
![image](https://user-images.githubusercontent.com/52755891/159236038-327be9b9-8509-4498-a495-0aa64fab51a6.png)

## Checklist
- [ ] Database schema is updated
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [ ] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [x] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
