### PR TITLE
fix: added 404 page

### DIFF
--- a/store/src/pages/404.js
+++ b/store/src/pages/404.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import dynamic from 'next/dynamic'
+import Head from 'next/head'
+
+const PageNotFound = dynamic(() =>
+   import('../sections/404').then(promise => promise.PageNotFound)
+)
+const NotFoundPage = () => {
+   return (
+      <>
+         <Head>Page not found!</Head>
+         <PageNotFound />
+      </>
+   )
+}
+
+export default NotFoundPage


### PR DESCRIPTION
## Description
If there are no folds it will redirect to the 404 page instead of the error page. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)



## Changes and Fixes
- Previously it was redirecting to the error page after merging this will redirect to the 404 page. 

## Screenshots 
(prefer all screen sizes images)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Affected Apps
- [x] Store
    