### PR TITLE
Fix/stickey category

### DIFF
--- a/store/src/components/on_demand_menu.jsx
+++ b/store/src/components/on_demand_menu.jsx
@@ -82,7 +82,7 @@ export const OnDemandMenu = props => {
                            to={each.name}
                            spy={true}
                            offset={
-                              headerLayoutStyle === 'layout-one' ? -130 : -150
+                              headerLayoutStyle === 'layout-one' ? -60 : -130
                            }
                         >
                            <span>

--- a/store/src/components/on_demand_menu.jsx
+++ b/store/src/components/on_demand_menu.jsx
@@ -5,6 +5,7 @@ import { onDemandMenuContext } from '../context'
 import { useOnClickOutside } from '../utils/useOnClickOutisde'
 import * as Scroll from 'react-scroll'
 import { useTranslation } from '../context'
+import { useConfig } from '../lib'
 
 export const OnDemandMenu = props => {
    // props
@@ -13,6 +14,11 @@ export const OnDemandMenu = props => {
    const showProductCount = showCount ?? showCount ?? true
    const [showMenuItems, setShowMenuItems] = useState('0')
    const [activeCategory, setActiveCategory] = useState(null)
+
+   const { configOf } = useConfig()
+   const headerLayoutStyle =
+      configOf('header-navigation', 'navigation')?.headerNavigation?.layout
+         ?.value?.value ?? 'layout-two'
    const ref = React.useRef()
    useOnClickOutside(ref, () => setShowMenuItems('0'))
 
@@ -49,7 +55,13 @@ export const OnDemandMenu = props => {
       return (
          <div
             className={classNames('hern-on-demand-menu__navigationAnchor')}
-            style={{ justifyContent: navAlignment }}
+            style={{
+               justifyContent: navAlignment,
+               top:
+                  headerLayoutStyle === 'layout-one'
+                     ? 0
+                     : 'var(--hern-navigation-menu-height)',
+            }}
          >
             <ul>
                {categories.map((each, index) => (
@@ -69,7 +81,9 @@ export const OnDemandMenu = props => {
                            activeClass="hern-on-demand-menu__navigationAnchor-li--active"
                            to={each.name}
                            spy={true}
-                           offset={-130}
+                           offset={
+                              headerLayoutStyle === 'layout-one' ? -130 : -150
+                           }
                         >
                            <span>
                               <span data-translation="true">{each.name}</span>

--- a/store/src/styles/components/on_demand_menu.scss
+++ b/store/src/styles/components/on_demand_menu.scss
@@ -79,7 +79,7 @@
    justify-content: center;
    /*Stick to the top  with the equal height of navigatin menu*/
    top: var(--hern-navigation-menu-height);
-   z-index: 10;
+   z-index: 99;
    width: inherit;
    background-color: #fff;
    > ul {

--- a/store/src/styles/components/on_demand_menu.scss
+++ b/store/src/styles/components/on_demand_menu.scss
@@ -82,6 +82,8 @@
    z-index: 99;
    width: inherit;
    background-color: #fff;
+   max-width: 1200px;
+   margin: 0 auto;
    > ul {
       display: flex;
       width: inherit;


### PR DESCRIPTION
## Description
Category on /order page for LayoutOne is sticking on the top on the wrong position. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes and Fixes
Category on /order page for LayoutOne is sticking on the top on the wrong position. 

## Screenshots 
(prefer all screen sizes images)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

Affected Apps
- [x] Store
    - [x] Product page
   