### PR TITLE
fix: otp length should be 6, special characters and alphabets are not allowed

### DIFF
--- a/store/src/components/login.jsx
+++ b/store/src/components/login.jsx
@@ -621,6 +621,12 @@ const OTPLogin = props => {
       }
    }
    const handleSubmitOTPKeyPress = event => {
+      if (event.which != 8 && event.which != 0 && event.which < 48 || event.which > 57){
+         event.preventDefault();
+      }
+      if( event.key !== 'Enter' && form.otp.length >= 6 ){
+         event.preventDefault();
+      }
       if (event.key === 'Enter') {
          if (
             !(resending || loading || !form.otp || (isNewUser && !form.email))


### PR DESCRIPTION
## Description
- OTP length should be 6
- No special characters and alphabet are allowed in OTP

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [x] Looks good on mobiles
- [x] Looks good on Tablets