### PR TITLE
fix: error message and graphql subscription in coupon selector

### DIFF
--- a/admin/src/shared/components/ConfigTemplateUI/UIComponents/index.js
+++ b/admin/src/shared/components/ConfigTemplateUI/UIComponents/index.js
@@ -36,6 +36,7 @@ import { Typography, Slider } from 'antd'
 
 import { BrandContext } from '../../../../App'
 import { useContext } from 'react'
+import { GET_BRAND_COUPONS } from '../../../graphql'
 
 const { Paragraph } = Typography
 
@@ -1054,20 +1055,6 @@ export const ImageWrapper = styled.div`
 `
 
 // Coupon Selector
-const COUPON_ID = gql`
-   subscription couponsCollections($brandId: Int) {
-      coupons: brandCoupons(
-         where: { isActive: { _eq: true }, brandId: { _eq: $brandId } }
-      ) {
-         coupon {
-            id
-            title: code
-            value: code
-         }
-      }
-   }
-`
-
 export const CouponSelector = props => {
    // props
    const { fieldDetail, marginLeft, path, onConfigChange, editMode } = props
@@ -1077,7 +1064,7 @@ export const CouponSelector = props => {
       loading: subsLoading,
       error: subsError,
       data: { coupons = [] } = {},
-   } = useSubscription(COUPON_ID, {
+   } = useSubscription(GET_BRAND_COUPONS, {
       variables: {
          brandId: brandContext.brandId,
       },
@@ -1095,7 +1082,7 @@ export const CouponSelector = props => {
       return <InlineLoader />
    }
    if (subsError) {
-      return <ErrorState message="product not found" />
+      return <ErrorState message="coupon not found" />
    }
 
    return (

--- a/admin/src/shared/graphql/index.js
+++ b/admin/src/shared/graphql/index.js
@@ -328,7 +328,7 @@ export const GET_BRAND_COUPONS = gql`
          coupon {
             id
             title: code
-            value: code
+            value: id
          }
       }
    }

--- a/admin/src/shared/graphql/index.js
+++ b/admin/src/shared/graphql/index.js
@@ -315,3 +315,21 @@ export const SETTINGS_QUERY = gql`
       }
    }
 `
+
+export const GET_BRAND_COUPONS = gql`
+   subscription couponsCollections($brandId: Int) {
+      coupons: brandCoupons(
+         where: {
+            isActive: { _eq: true }
+            brandId: { _eq: $brandId }
+            coupon: { isActive: { _eq: true } }
+         }
+      ) {
+         coupon {
+            id
+            title: code
+            value: code
+         }
+      }
+   }
+`


### PR DESCRIPTION
## Description
- Fix the error message in the coupon selector.
- Move graphql subscription into the correct folder.
- Modified graphql subscription to consider a coupon active only if that coupon is active and it's also active for the current brand.
 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets