### PR TITLE
tweak: add hernlazyimage in slider section 2

### DIFF
--- a/store/src/sections/slider-section-2/index.js
+++ b/store/src/sections/slider-section-2/index.js
@@ -3,6 +3,7 @@ import { Carousel } from 'antd'
 import { ArrowLeftIcon, ArrowRightIcon } from '../../assets/icons'
 import { HernLazyImage } from '../../utils/hernImage'
 import { config } from 'bluebird'
+import { isClient } from '../../utils'
 
 export const SliderSection2 = ({ config }) => {
    const showDotsOnSlider =
@@ -88,9 +89,33 @@ export const SliderSection2 = ({ config }) => {
 }
 
 const SliderDiv = ({ images, index }) => {
+   const sliderImageSize = React.useMemo(() => {
+      const innerWidth = isClient ? window.innerWidth : ''
+      if (0 <= innerWidth && innerWidth <= 599) {
+         return {
+            width: 220,
+            height: 260,
+         }
+      } else if (600 <= innerWidth && innerWidth <= 1024) {
+         return {
+            width: 250,
+            height: 340,
+         }
+      } else if (1024 <= innerWidth) {
+         return {
+            width: 360,
+            height: 480,
+         }
+      }
+   }, [])
    return (
-      <div class="slider-div">
-         <img class="slider-img" src={images[index] ? images[index] : ''} />
+      <div className="slider-div">
+         <HernLazyImage
+            className="slider-img"
+            dataSrc={images[index] ? images[index] : ''}
+            width={sliderImageSize.width}
+            height={sliderImageSize.height}
+         />
       </div>
    )
 }


### PR DESCRIPTION
## Description
images in slider section on home page are load before visible in view port

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- Add `<HernLazyImage/>` in slider section image.

## Screenshots 


## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
