### PR TITLE
Fix/UI ingredients form in recipe app

### DIFF
--- a/admin/src/shared/components/Sidebar/styled.js
+++ b/admin/src/shared/components/Sidebar/styled.js
@@ -36,7 +36,7 @@ const Styles = {
          :hover {
             position: absolute;
             width: 222px;
-            z-index: 3;
+            z-index: 700;
          }
       `
    ),


### PR DESCRIPTION
## Description
Fixed the side bar overlapping with the  ingredients form in recipe app .

## Type of change
Changed in the styled js file of Sidebar.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- Increased the Z-index.

## Screenshots 
Previous One
![Screenshot (41)](https://user-images.githubusercontent.com/79412550/163181485-66ea21a4-7414-4758-9609-68ba70d1c6e7.png)
After fixing 
![Screenshot (42)](https://user-images.githubusercontent.com/79412550/163181538-beb945b9-13e5-4037-8329-43dd4a73528e.png)


## Checklist
- [ ] Database schema is updated
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [ ] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [x] Admin
    - [ ] Order
    - [ ] CRM
    - [x] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
