### PR TITLE
fix: close prop is not passing

### DIFF
--- a/admin/src/apps/crm/views/Listings/CouponListing/index.js
+++ b/admin/src/apps/crm/views/Listings/CouponListing/index.js
@@ -306,7 +306,7 @@ const CouponListing = () => {
          <Banner id="crm-app-coupons-listing-top" />
          <Tunnels tunnels={couponTunnels}>
             <Tunnel layer={1} size="md">
-               <CreateCoupon closeTunnel={closeCouponTunnel} />
+               <CreateCoupon close={closeCouponTunnel} />
             </Tunnel>
          </Tunnels>
          <Flex


### PR DESCRIPTION
## Description
- Close prop is passing as closed tunnel 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Changes and Fixes
- make  closeTunnel prop to close 

## Screenshots 
![image](https://user-images.githubusercontent.com/43314398/163401543-d179d82d-0d80-4e34-8899-02d00326bd01.png)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

Affected Apps
- [x] Admin
    - [x] CRM
    