### PR TITLE
fix: remove window onload on queries

### DIFF
--- a/store/src/context/cart.js
+++ b/store/src/context/cart.js
@@ -13,12 +13,7 @@ import {
 import { useUser } from '.'
 import { useConfig } from '../lib'
 import { useToasts } from 'react-toast-notifications'
-import {
-   combineCartItems,
-   useQueryParamState,
-   useWindowOnload,
-   isKiosk,
-} from '../utils'
+import { combineCartItems, useQueryParamState, isKiosk } from '../utils'
 import { useTranslation } from './language'
 
 export const CartContext = React.createContext()
@@ -63,7 +58,6 @@ export const CartProvider = ({ children }) => {
    const [combinedCartItems, setCombinedCartData] = useState(null)
    const [showCartIconToolTip, setShowCartIconToolTip] = useState(false)
    const [dineInTableInfo, setDineInTableInfo] = useState(null)
-   const { isWindowLoading } = useWindowOnload()
 
    React.useEffect(() => {
       // case 1 - user is not authenticated
@@ -91,7 +85,7 @@ export const CartProvider = ({ children }) => {
       error: getInitialCart,
       data: cartData = {},
    } = useSubscription(GET_CART, {
-      skip: isWindowLoading || !storedCartId,
+      skip: !storedCartId,
       variables: {
          where: {
             id: {
@@ -119,7 +113,7 @@ export const CartProvider = ({ children }) => {
       error: cartItemsError,
       data: cartItemsData,
    } = useSubscription(GET_CART_ITEMS_BY_CART, {
-      skip: isWindowLoading || !storedCartId,
+      skip: !storedCartId,
       variables: {
          where: {
             level: {
@@ -461,9 +455,7 @@ export const CartProvider = ({ children }) => {
                },
             },
          },
-         skip:
-            !(brand?.id && user?.keycloakId && orderTabs.length > 0) ||
-            isWindowLoading,
+         skip: !(brand?.id && user?.keycloakId && orderTabs.length > 0),
          fetchPolicy: 'no-cache',
          onSubscriptionData: ({ subscriptionData }) => {
             console.log('subscriptionData', subscriptionData)

--- a/store/src/context/onDemandMenu.js
+++ b/store/src/context/onDemandMenu.js
@@ -1,7 +1,6 @@
 import { useQuery } from '@apollo/react-hooks'
 import React from 'react'
 import { PRODUCTS_BY_CATEGORY } from '../graphql'
-import { useWindowOnload } from '../utils'
 import { useConfig } from './../lib'
 
 //on demand menu context
@@ -35,10 +34,9 @@ export const OnDemandMenuProvider = ({ children }) => {
       reducer,
       initialState
    )
-   const { isWindowLoading } = useWindowOnload()
 
    useQuery(PRODUCTS_BY_CATEGORY, {
-      skip: isWindowLoading || isConfigLoading || !brand?.id,
+      skip: isConfigLoading || !brand?.id,
       variables: {
          params: {
             brandId: brand?.id,

--- a/store/src/lib/config.js
+++ b/store/src/lib/config.js
@@ -4,12 +4,7 @@ import has from 'lodash/has'
 import isEmpty from 'lodash/isEmpty'
 import React from 'react'
 import { ORDER_TAB } from '../graphql'
-import {
-   get_env,
-   isClient,
-   useQueryParamState,
-   useWindowOnload,
-} from '../utils'
+import { get_env, isClient, useQueryParamState } from '../utils'
 const ConfigContext = React.createContext()
 
 const initialState = {
@@ -90,10 +85,9 @@ export const ConfigProvider = ({ children }) => {
 
    const [showLocationSelectorPopup, setShowLocationSelectionPopup] =
       React.useState(false)
-   const { isWindowLoading } = useWindowOnload()
 
    useQuery(ORDER_TAB, {
-      skip: isWindowLoading || isLoading || !orderInterfaceType,
+      skip: isLoading || !orderInterfaceType,
       variables: {
          where: {
             isActive: { _eq: true },

--- a/store/src/sections/product-gallery/index.js
+++ b/store/src/sections/product-gallery/index.js
@@ -8,12 +8,7 @@ import { Loader } from '../../components'
 import { ProductCard } from '../../components/product_card'
 import { PRODUCTS } from '../../graphql'
 import { useConfig } from '../../lib'
-import {
-   getRoute,
-   isClient,
-   setThemeVariable,
-   useWindowOnload,
-} from '../../utils'
+import { getRoute, isClient, setThemeVariable } from '../../utils'
 import { CustomArea } from '../featuredCollection/productCustomArea'
 
 export const ProductGallery = ({ config }) => {
@@ -23,7 +18,6 @@ export const ProductGallery = ({ config }) => {
    )
    const [status, setStatus] = React.useState('loading')
    const { brand, locationId } = useConfig()
-   const { isWindowLoading } = useWindowOnload()
 
    const argsForByLocation = React.useMemo(
       () => ({
@@ -37,7 +31,6 @@ export const ProductGallery = ({ config }) => {
    const { loading: productsLoading, error: productsError } = useQuery(
       PRODUCTS,
       {
-         skip: isWindowLoading,
          variables: {
             ids: config.data.products.value,
             priceArgs: argsForByLocation,


### PR DESCRIPTION
## Description
browser window was taking more  time to load. So queries depending on `window onload` was also delaying. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- Remove window onload dependency on queries

## Screenshots 
no

## Checklist
- [ ] Database schema is updated
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [ ] Store
    - [ ] SEO
    - [x] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
