### PR TITLE
fix: handle case when productOptionType is null in modifier_popup

### DIFF
--- a/store/src/components/modifier_popup.jsx
+++ b/store/src/components/modifier_popup.jsx
@@ -73,11 +73,17 @@ export const ModifierPopup = props => {
          .value()
       return groupedData
    }, [productData])
+   
+   const defaultOptionType = productData.productOptions.find(
+      x => x.id === productData.defaultProductOptionId
+   )?.type
+   
    const [productOptionType, setProductOptionType] = useState(
-      productData.productOptions.find(
-         x => x.id === productData.defaultProductOptionId
-      )?.type ||
-      productOptionsGroupedByProductOptionType[0]['type']
+      defaultOptionType ? 
+         defaultOptionType : 
+         defaultOptionType==null ? 
+            'null' : 
+            productOptionsGroupedByProductOptionType[0]['type']
    )
 
    const showStepViewProductOptionAndModifiers = React.useMemo(


### PR DESCRIPTION
## Description
This PR resolves #896 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots 
![Web capture_3-5-2022_16562_localhost](https://user-images.githubusercontent.com/52407451/166444806-216675d7-c843-4432-9b00-47ade69cdb7f.jpeg)

## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets