### PR TITLE
fix: replace billingDetails with cartOwnerBilling

### DIFF
--- a/store/src/components/cart_billing_details.js
+++ b/store/src/components/cart_billing_details.js
@@ -2,32 +2,37 @@ import React from 'react'
 
 import { useTranslation, useUser } from '../context'
 import { formatCurrency } from '../utils'
+import { useConfig } from '../lib'
 
-export const CartBillingDetails = ({ billing, tip }) => {
+export const CartBillingDetails = ({ cart, billing, tip }) => {
    const { user } = useUser()
    const { t, dynamicTrans, locale } = useTranslation()
    const currentLang = React.useMemo(() => locale, [locale])
+   const { configOf } = useConfig()
    React.useEffect(() => {
       const languageTags = document.querySelectorAll(
          '[data-translation="true"]'
       )
       dynamicTrans(languageTags)
    }, [currentLang])
-
+   const loyaltyPointsUsage = configOf('Loyalty Points Usage', 'rewards')[
+      'Loyalty Points Usage'
+   ]
+   const loyaltyPointsConversionRate = parseInt(
+      loyaltyPointsUsage?.ConversionRate?.value
+   )
    return (
       <div className="hern-cart-billing-details">
          <h3>{t('Bill Details')}</h3>
          {billing && (
             <ul className="hern-cart-billing-details-list">
                <li>
-                  <span data-translation="true">{billing.itemTotal.label}</span>
-                  <span>{formatCurrency(billing.itemTotal.value || 0)}</span>
+                  <span>{t('Item total')}</span>
+                  <span>{formatCurrency(billing.itemTotal || 0)}</span>
                </li>
                <li>
-                  <span data-translation="true">
-                     {billing.deliveryPrice.label}
-                  </span>
-                  {billing.deliveryPrice.value === 0 ? (
+                  <span>{t('Delivery fee')}</span>
+                  {billing.deliveryPrice === 0 ? (
                      <span
                         style={{
                            color: 'var(--hern-accent)',
@@ -37,41 +42,59 @@ export const CartBillingDetails = ({ billing, tip }) => {
                         {t('free')}
                      </span>
                   ) : (
-                     <span>
-                        {formatCurrency(billing.deliveryPrice.value || 0)}
-                     </span>
+                     <span>{formatCurrency(billing.deliveryPrice || 0)}</span>
                   )}
                </li>
-               <li>
-                  <span data-translation="true">
-                     {billing.tax?.label || 'Tax'}
-                  </span>
-                  <span>{formatCurrency(billing.tax?.value || 0)}</span>
-               </li>
-               {billing.discount.value > 0 && (
-                  <li>
-                     <span data-translation="true">
-                        {billing.discount.label}
-                     </span>
+               {billing.itemTotalInclusiveTax > 0 ? (
+                  <li title="Included with price">
+                     <span>{t('Tax (Inclusive)')}</span>
                      <span>
-                        - {formatCurrency(billing.discount.value || 0)}
+                        {formatCurrency(
+                           Math.round(
+                              (billing.itemTotalInclusiveTax + Number.EPSILON) *
+                                 100
+                           ) / 100 || billing.itemTotalInclusiveTax
+                        )}
+                     </span>
+                  </li>
+               ) : (
+                  <li>
+                     <span>{t('Tax')}</span>
+                     <span>
+                        {formatCurrency(
+                           Math.round(
+                              (billing.itemTotalTaxExcluded + Number.EPSILON) *
+                                 100
+                           ) / 100 || billing.itemTotalTaxExcluded
+                        )}
                      </span>
                   </li>
                )}
-               {user?.keycloakId && billing.loyaltyPointsUsed.value > 0 && (
+               {billing.totalDiscount > 0 && (
                   <li>
-                     <span data-translation="true">
-                        {billing.loyaltyPointsUsed.label}
-                     </span>
-                     <span>{billing.loyaltyPointsUsed.value}</span>
+                     <span>{t('Total Discount')}</span>
+                     <span>- {formatCurrency(billing.totalDiscount || 0)}</span>
                   </li>
                )}
-               {user?.keycloakId && billing.walletAmountUsed.value > 0 && (
+               {user?.keycloakId && billing.loyaltyAmountApplied > 0 && (
                   <li>
-                     <span data-translation="true">
-                        {billing.walletAmountUsed.label}
+                     <span>{t('Loyalty amount applied')}</span>
+                     <span>
+                        <span
+                           title={
+                              loyaltyPointsConversionRate &&
+                              `${loyaltyPointsConversionRate} (Conversion Rate) * ${cart.loyaltyPointsUsed}`
+                           }
+                        >
+                           {billing.loyaltyAmountApplied}
+                        </span>
                      </span>
-                     <span>{billing.walletAmountUsed.value}</span>
+                  </li>
+               )}
+               {user?.keycloakId && billing.walletAmountUsed > 0 && (
+                  <li>
+                     <span>{t('Wallet amount used')}</span>
+                     <span>{billing.walletAmountUsed}</span>
                   </li>
                )}
                {tip && tip !== 0 && (
@@ -81,10 +104,8 @@ export const CartBillingDetails = ({ billing, tip }) => {
                   </li>
                )}
                <li className="hern-cart-billing-details-total-price">
-                  <span data-translation="true">
-                     {billing.totalPrice.label}
-                  </span>
-                  <span>{formatCurrency(billing.totalPrice.value || 0)}</span>
+                  <span>{t('Total')}</span>
+                  <span>{formatCurrency(billing.balanceToPay || 0)}</span>
                </li>
             </ul>
          )}

--- a/store/src/components/cart_order_details.js
+++ b/store/src/components/cart_order_details.js
@@ -93,7 +93,7 @@ export const CartOrderDetails = () => {
          {/* List of ordered items   */}
          <CartItems products={cart?.cartItems} border={true} title={true} />
          {/* Cart billing details  */}
-         <CartBillingDetails billing={cart?.billingDetails} />
+         <CartBillingDetails cart={cart} billing={cart?.cartOwnerBilling} />
       </>
    )
 }

--- a/store/src/components/order_details.js
+++ b/store/src/components/order_details.js
@@ -70,7 +70,10 @@ const OrderDetails = () => {
             />
          )}
          <Divider />
-         <CartBillingDetails billing={orderDetails?.cart?.billing} />
+         <CartBillingDetails
+            cart={orderDetails?.cart}
+            billing={orderDetails?.cart?.cartOwnerBilling}
+         />
       </div>
    )
 }

--- a/store/src/sections/cart/CartDetails.js
+++ b/store/src/sections/cart/CartDetails.js
@@ -113,7 +113,7 @@ export const CartDetails = () => {
                <LoyaltyPoints cart={cartState.cart} version={2} />
             )}
          <Divider />
-         <CartBillingDetails billing={cart.billing} />
+         <CartBillingDetails cart={cart} billing={cart.cartOwnerBilling} />
       </section>
    )
 }


### PR DESCRIPTION
## Description
- Replace `billingDetails` with `cartOwnerBilling`
- This PR requires #895 to be done 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Database schema is updated
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [x] Checkout
    - [x] Payment