### PR TITLE
fix: refactor condition when defaultOptionType is null

### DIFF
--- a/store/src/components/modifier_popup.jsx
+++ b/store/src/components/modifier_popup.jsx
@@ -81,7 +81,7 @@ export const ModifierPopup = props => {
    const [productOptionType, setProductOptionType] = useState(
       defaultOptionType ? 
          defaultOptionType : 
-         defaultOptionType==null ? 
+         defaultOptionType===null ? 
             'null' : 
             productOptionsGroupedByProductOptionType[0]['type']
    )


### PR DESCRIPTION
## Description
- This PR refactor condition when defaultOptionType is null in the product modifier popup

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots 
![Web capture_4-5-2022_174253_localhost](https://user-images.githubusercontent.com/52407451/166678823-3f07d5c6-f557-41a4-8c2b-0571552d1911.jpeg)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [x] Product page