### PR TITLE
fix: replace balanceToPay with totalToPay in cart_billing_details

### DIFF
--- a/store/src/components/cart_billing_details.js
+++ b/store/src/components/cart_billing_details.js
@@ -105,7 +105,7 @@ export const CartBillingDetails = ({ cart, billing, tip }) => {
                )}
                <li className="hern-cart-billing-details-total-price">
                   <span>{t('Total')}</span>
-                  <span>{formatCurrency(billing.balanceToPay || 0)}</span>
+                  <span>{formatCurrency(billing.totalToPay || 0)}</span>
                </li>
             </ul>
          )}


### PR DESCRIPTION
## Description
In this PR, balanceToPay in cart_billing_details is replaced with totalToPay

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes and Fixes
- This PR fix, the total shown on the view order page as before it will be zero after the payment 

## Screenshots 
Before - 

![Web capture_6-5-2022_144444_localhost](https://user-images.githubusercontent.com/52407451/167104355-68cc7ac9-94f0-4677-9d63-efe022880d84.jpeg)

Now - 

![Web capture_6-5-2022_14511_localhost](https://user-images.githubusercontent.com/52407451/167104412-70c97b09-a09e-45a4-ac69-637b0b3ae5a7.jpeg)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [x] Payment