### PR TITLE
fix: fix error in clone recipe when an ingredient does not have a pro…

### DIFF
--- a/admin/src/apps/products/views/Forms/RecipeForm/index.js
+++ b/admin/src/apps/products/views/Forms/RecipeForm/index.js
@@ -238,7 +238,7 @@ const RecipeForm = () => {
       const clonedSimpleRecipeIngredients = state.simpleRecipeIngredients.map(
          ing => ({
             ingredientId: ing.ingredient.id,
-            processingId: ing.processing.id,
+            processingId: ing.processing?.id,
             position: ing.position,
          })
       )


### PR DESCRIPTION
## Description
This PR resolves Issue #788 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes and Fixes
- Put Processing Id null for an Ingredient when it's not available while cloning

## Screenshots 
![Web capture_6-5-2022_201310_localhost](https://user-images.githubusercontent.com/52407451/167157120-8d1598c9-ced8-4890-9969-5ad60db828f4.jpeg)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Admin
    - [x] Product app