### PR TITLE
Fix  change plan does not show on select delivery

### DIFF
--- a/store/public/lazysizes.min.js
+++ b/store/public/lazysizes.min.js
@@ -285,7 +285,7 @@
                      if (!u) {
                         u =
                            !H.expand || H.expand < 1
-                              ? O.clientHeight > 500 && O.clientWidth > 500
+                              ? O?.clientHeight > 500 && O?.clientWidth > 500
                                  ? 500
                                  : 370
                               : H.expand

--- a/store/src/components/plan_info.js
+++ b/store/src/components/plan_info.js
@@ -41,7 +41,10 @@ const PlanInfo = () => {
       icon: subscription_subscriptionItemCount[0]?.subscriptionServing
          ?.subscriptionTitle?.metaDetails?.icon,
    }
-   const planInfo = user?.isSubscriber ? planInfoUser : planInfoFetched
+   const planInfo =
+      user?.isSubscriber && localStorage.getItem('changing-plan') !== 'true'
+         ? planInfoUser
+         : planInfoFetched
 
    return (
       <div className="hern-plan-info">

--- a/store/src/sections/checkout-page/index.js
+++ b/store/src/sections/checkout-page/index.js
@@ -330,7 +330,7 @@ const FulfillmentAddress = ({ cart }) => {
       if (elem) {
          setThemeVariable(
             '--user-info-section-bottom',
-            elem.clientHeight + 50 + 'px'
+            elem?.clientHeight + 50 + 'px'
          )
       }
    }, [isOpen])


### PR DESCRIPTION
## Description
1) When change-plan is selected, the delivery page shows data of previous selected plan. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- condition added to check is user is changing plan or not 
- clientHeigth pop-up error is fixed

## Screenshots 
(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
