### PR TITLE
Fix/subscription-store-issues-inifnite-loop

### DIFF
--- a/store/src/context/cart.js
+++ b/store/src/context/cart.js
@@ -580,20 +580,20 @@ export const CartProvider = ({ children }) => {
                      const addressInCart =
                         subscriptionData.data.carts[0].address
                      const addressToBeSaveInLocal = {
-                        city: addressInCart.city,
-                        country: addressInCart.country,
-                        label: addressInCart.label,
-                        landmark: addressInCart.landmark,
-                        latitude: addressInCart.lat,
-                        line1: addressInCart.line1,
-                        line2: addressInCart.line2,
-                        longitude: addressInCart.lng,
-                        mainText: addressInCart.line1,
-                        notes: addressInCart.notes,
-                        secondaryText: `${addressInCart.city}, ${addressInCart.state} ${addressInCart.zipcode}, ${addressInCart.country}`,
-                        state: addressInCart.state,
-                        zipcode: addressInCart.zipcode,
-                        searched: addressInCart.searched || '',
+                        city: addressInCart?.city,
+                        country: addressInCart?.country,
+                        label: addressInCart?.label,
+                        landmark: addressInCart?.landmark,
+                        latitude: addressInCart?.lat,
+                        line1: addressInCart?.line1,
+                        line2: addressInCart?.line2,
+                        longitude: addressInCart?.lng,
+                        mainText: addressInCart?.line1,
+                        notes: addressInCart?.notes,
+                        secondaryText: `${addressInCart?.city}, ${addressInCart?.state} ${addressInCart?.zipcode}, ${addressInCart?.country}`,
+                        state: addressInCart?.state,
+                        zipcode: addressInCart?.zipcode,
+                        searched: addressInCart?.searched || '',
                      }
                      const orderTabForLocal =
                         subscriptionData.data.carts[0].fulfillmentInfo?.type ||


### PR DESCRIPTION
## Description
- Worked on fixing with the infinite loop that was caused by the address issue in the cart.js of the subscription store. This has also resolved the undefined city that kept on popping when you do not have the address stored locally when using incognito.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- Description of changes and all fixes in this issue

## Screenshots 
(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
