### PR TITLE
fix: visibilty of digits in phone number and what to show instead of …

### DIFF
--- a/store/src/components/kiosk/fulfillment.js
+++ b/store/src/components/kiosk/fulfillment.js
@@ -477,8 +477,8 @@ const PhoneNumber = ({
    
    useEffect( ()=> {
 
-      const show = "*"
-      const hidePhoneNumber = true;
+      const show = config?.phoneNoScreenSettings?.visibilityOfPhoneNumber.label;
+      const hidePhoneNumber = (config?.phoneNoScreenSettings?.visibilityOfPhoneNumber.value)? false : true;
       let phoneNumberlen = number.length
 
       if (phoneNumberInputRef.current){


### PR DESCRIPTION
## Description
While entering a phone number in 'Dine in' inside kiosk, before it was hardcoded to hide a phone number and show "*" instead of digits. Now It changed to follow what provided in config for that client.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- changed file 'HERN\store\src\components\kiosk\fulfillment.js'

## Screenshots 
(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [x] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
