### PR TITLE
fix: fixed customer not able to register with mobile app

### DIFF
--- a/server/entities/auth/controllers.js
+++ b/server/entities/auth/controllers.js
@@ -82,7 +82,7 @@ export const authHandler = async (req, res) => {
                                  brandId: brandId
                               }
                            },
-                           email: email,
+                           ...(email && { email: email }),
                            keycloakId: insertCustomer.id
                         }
                      })


### PR DESCRIPTION
## Description
- Fixed customer not able to register with mobile app

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes and Fixes
- Email while creating a customer in the CRM table should be NULL but it was going as an empty string, to fix this we should not pass the email parameter when the email is not present.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Looks good on large screens
- [x] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Server
    - [ ] Mobile App Auth