### PR TITLE
fix: Delete confirmation for removing cart item from cart

### DIFF
--- a/store/src/components/kiosk/cart.js
+++ b/store/src/components/kiosk/cart.js
@@ -373,7 +373,8 @@ const CartCard = props => {
    const [showChooseIncreaseType, setShowChooseIncreaseType] = useState(false) // show I'll choose or repeat last one popup
    const [showModifier, setShowModifier] = useState(false) // show modifier popup
    const [forRepeatLastOne, setForRepeatLastOne] = useState(false) // to run repeatLastOne fn in PRODUCTS_ONE query
-
+   const [isConfirmationForDeleteCartItemModalVisible, 
+      setConfirmationForDeleteCartItemModalVisible] = useState(false);
    let totalPrice = 0
    let totalDiscount = 0
    const price = product => {
@@ -1003,9 +1004,59 @@ const CartCard = props => {
                      title="Delete"
                      size={50}
                      onClick={() => {
-                        removeCartItems(productData.ids)
+                        if(config?.cartCardSettings?.deleteConfirmation?.value || false){
+                           setConfirmationForDeleteCartItemModalVisible(true)
+                        } else{
+                           removeCartItems(productData.ids)
+                        }
                      }}
                   />
+                  { isConfirmationForDeleteCartItemModalVisible &&
+                     (config?.cartCardSettings?.deleteConfirmation?.value || false) &&
+                     <Modal
+                        title={formatMessage({ id: 'Are you sure you want to remove this product from your cart' })}
+                        visible={isConfirmationForDeleteCartItemModalVisible}
+                        centered={true}
+                        onCancel={() => {
+                           setConfirmationForDeleteCartItemModalVisible(false)
+                        }}
+                        closable={false}
+                        footer={null}
+                     >
+                        <div className="hern-kiosk__cart-item-delete-confirmation-button-div">
+                           <Button
+                              variant="outline"
+                              onClick={() => {
+                                 setConfirmationForDeleteCartItemModalVisible(false)
+                              }}
+                              style={{ margin: "2px",
+                                       fontSize: "20px", 
+                                       border: `2px solid ${config?.kioskSettings?.theme?.primaryColor?.value ?? "black"}`, 
+                                       paddingBottom: "2.5rem",
+                                       width: "40%",
+                                       paddingTop: "0.8rem"
+                                    }}
+                           >
+                              {t(`Cancel`)}
+                           </Button>
+                           <Button
+                              onClick={() => {
+                                 setConfirmationForDeleteCartItemModalVisible(false)
+                                 removeCartItems(productData.ids)
+                              }}
+                              style={{fontSize: "20px", 
+                                       backgroundColor: config?.kioskSettings?.theme?.primaryColor?.value ?? "black", 
+                                       color:"white", 
+                                       paddingBottom: "2.5rem",
+                                       width: "40%",
+                                       paddingTop: "0.8rem"
+                                    }}
+                           >
+                              {t('Yes, Remove')}
+                           </Button>
+                        </div>
+                     </Modal> 
+                  }
                </div>
                <div
                   className="hern-kiosk__cart-cards-price"

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -1015,7 +1015,18 @@
    display: flex;
    justify-content: flex-end;
 }
-
+.ant-modal-content {
+   padding: 1rem;
+   border-radius: .5rem;
+}
+.ant-modal-title {
+   font-size: 26px;
+}
+.hern-kiosk__cart-item-delete-confirmation-button-div {
+   width: 100%;
+   display: inline-flex;
+   justify-content: space-between;
+}
 .hern-kiosk__cart-page-footer {
    padding: 0;
    height: calc(40em + 120px);


### PR DESCRIPTION
## Description
added confirmation for removing items from the cart, It is config based and by default it's value is false, so for removing item from cart won't ask for confirmation by default

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots 
![image](https://user-images.githubusercontent.com/77051687/179175305-8c6ac331-aeac-4b26-a5bf-00d4b8ad2d92.png)

(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [x] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
