### PR TITLE
fix: design issue created by Delete Confirmation commit for ant-modal

### DIFF
--- a/store/src/components/kiosk/cart.js
+++ b/store/src/components/kiosk/cart.js
@@ -1017,6 +1017,7 @@ const CartCard = props => {
                         title={formatMessage({ id: 'Are you sure you want to remove this product from your cart' })}
                         visible={isConfirmationForDeleteCartItemModalVisible}
                         centered={true}
+                        className = "hern-kiosk__cart-item-delete-confirmation-modal"
                         onCancel={() => {
                            setConfirmationForDeleteCartItemModalVisible(false)
                         }}

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -1015,12 +1015,14 @@
    display: flex;
    justify-content: flex-end;
 }
-.ant-modal-content {
-   padding: 1rem;
-   border-radius: .5rem;
-}
-.ant-modal-title {
-   font-size: 26px;
+.hern-kiosk__cart-item-delete-confirmation-modal {
+   .ant-modal-content {
+      padding: 1rem;
+      border-radius: .5rem;
+   }
+   .ant-modal-title {
+      font-size: 26px;
+   }
 }
 .hern-kiosk__cart-item-delete-confirmation-button-div {
    width: 100%;


### PR DESCRIPTION
## Description
Solved the issue of modal design created by delete confirmation branch

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- It is now not affecting any ant modal design

## Screenshots 
![image](https://user-images.githubusercontent.com/77051687/179212463-0edb333f-20bc-4f2e-baf7-80bf45207b9a.png)

(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [x] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
