### PR TITLE
tweak: image icon with plan title on selectPlan page

### DIFF
--- a/store/src/sections/select-plan/plans.js
+++ b/store/src/sections/select-plan/plans.js
@@ -323,7 +323,14 @@ const PlansDetails = ({ selectedPlan, list, config, planViewConfig }) => {
                   - Include plateIllustration
                 */}
                   <span>
-                     <PlateIllustration />
+                     {selectedPlan.metaDetails?.icon ? (
+                        <img
+                           src={selectedPlan.metaDetails?.icon}
+                           style={{ height: '29px', width: '29px' }}
+                        />
+                     ) : (
+                        <PlateIllustration />
+                     )}
                   </span>
                   {selectedPlan.title}
                </p>


### PR DESCRIPTION
## Description
Plan icon can be seen now with plan title on select plan page in right column

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots 
![image](https://user-images.githubusercontent.com/89663357/179276347-0a2a1849-ccd6-4c23-b72a-b588feee2192.png)


## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [ ] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [x] Plan page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
