### PR TITLE
Fixed Missing default Image & Slide-arrows in product card store/order

### DIFF
--- a/store/src/components/cart_product.jsx
+++ b/store/src/components/cart_product.jsx
@@ -31,6 +31,7 @@ export const CartProduct = ({ product, isRemovable, onDelete }) => {
                   alt={product.name}
                   className="image__thumbnail"
                />
+               
             ) : (
                <img src={noProductImage} alt={product.name} />
             )}

--- a/store/src/components/product_card.jsx
+++ b/store/src/components/product_card.jsx
@@ -2,10 +2,10 @@ import classNames from 'classnames'
 import React from 'react'
 import { Slide } from 'react-slideshow-image'
 import { useTranslation } from '../context'
+import { useConfig } from '../lib'
 import { formatCurrency, isClient } from '../utils'
 import { HernLazyImage } from '../utils/hernImage'
 import { ModifierPopup, ModifierPopupForUnAvailability } from './index'
-// import { useConfig } from '../lib'
 // if (isClient) {
 //    import('lazysizes/plugins/unveilhooks/ls.unveilhooks').then(module => module)
 // }
@@ -51,7 +51,7 @@ export const ProductCard = props => {
    } = props
    // console.log('🚀 ~ file: product_card.jsx ~ line 50 ~ data', data)
    const { t, dynamicTrans, locale } = useTranslation()
-
+   const {noProductImage} = useConfig()
    const currentLang = React.useMemo(() => locale, [locale])
    const slideRef = React.useRef()
    const properties = {
@@ -141,7 +141,44 @@ export const ProductCard = props => {
                         {...properties}
                      >
                         {data.assets.images.map((each, index) => {
-                           return (
+
+                           // each = noProductImage
+                           // console.log("abcde",noProductImage)
+                           console.log("EACH",each)
+                           if (each === undefined || each === null)
+                              {
+                                 return (
+                              <div key={each}>
+                                 
+                                 <HernLazyImage
+                                    // src={each}
+                                    dataSrc={noProductImage}
+                                    alt={data.name}
+                                    className={classNames(
+                                       'hern-product-card__image',
+                                       {
+                                          'hern-product-card__image--aspect-ratio':
+                                             maintainRatio,
+                                       }
+                                    )}
+                                    onClick={e => {
+                                       if (onImageClick) {
+                                          e.stopPropagation()
+                                          onImageClick()
+                                       }
+                                    }}
+                                    style={{
+                                       cursor: onImageClick ? 'pointer' : null,
+                                    }}
+                                    width={productImageSize.width}
+                                    height={productImageSize.height}
+                                 />
+                              </div>
+                           )
+                              }
+                           else {
+                              console.log("jjjjj")
+                              return (
                               <div key={each}>
                                  {/* <div
                                     className={classNames(
@@ -156,6 +193,7 @@ export const ProductCard = props => {
                                     // }}
                                     data-bg={each}
                                  ></div> */}
+                                 
                                  <HernLazyImage
                                     // src={each}
                                     dataSrc={each}
@@ -181,6 +219,7 @@ export const ProductCard = props => {
                                  />
                               </div>
                            )
+                           }
                         })}
                      </Slide>
                      {IconOnImage && (

--- a/store/src/components/product_card.jsx
+++ b/store/src/components/product_card.jsx
@@ -5,10 +5,11 @@ import { useTranslation } from '../context'
 import { formatCurrency, isClient } from '../utils'
 import { HernLazyImage } from '../utils/hernImage'
 import { ModifierPopup, ModifierPopupForUnAvailability } from './index'
+// import { useConfig } from '../lib'
 // if (isClient) {
 //    import('lazysizes/plugins/unveilhooks/ls.unveilhooks').then(module => module)
 // }
-
+   
 export const ProductCard = props => {
    const {
       data,
@@ -50,6 +51,7 @@ export const ProductCard = props => {
    } = props
    // console.log('🚀 ~ file: product_card.jsx ~ line 50 ~ data', data)
    const { t, dynamicTrans, locale } = useTranslation()
+
    const currentLang = React.useMemo(() => locale, [locale])
    const slideRef = React.useRef()
    const properties = {
@@ -58,9 +60,9 @@ export const ProductCard = props => {
       transitionDuration: 500,
       infinite: false,
       easing: 'ease',
-      ...(showImage && data.assets.images.length !== 1
-         ? { arrows: showSliderArrows }
-         : { arrows: false }),
+      ...(showImage && data.assets.images.length == 1
+         ? { arrows: false }
+         : { arrows: showSliderArrows }),
       ...(showImage &&
          data.assets.images.length !== 1 &&
          showSliderIndicators && {
@@ -136,6 +138,7 @@ export const ProductCard = props => {
                         ref={slideRef}
                         infinite={autoPlaySlider}
                         autoplay={autoPlaySlider}
+                        {...properties}
                      >
                         {data.assets.images.map((each, index) => {
                            return (

--- a/store/src/components/product_card.jsx
+++ b/store/src/components/product_card.jsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import { isEmpty } from 'lodash'
 import React from 'react'
 import { Slide } from 'react-slideshow-image'
 import { useTranslation } from '../context'
@@ -6,10 +7,7 @@ import { useConfig } from '../lib'
 import { formatCurrency, isClient } from '../utils'
 import { HernLazyImage } from '../utils/hernImage'
 import { ModifierPopup, ModifierPopupForUnAvailability } from './index'
-// if (isClient) {
-//    import('lazysizes/plugins/unveilhooks/ls.unveilhooks').then(module => module)
-// }
-   
+
 export const ProductCard = props => {
    const {
       data,
@@ -49,9 +47,8 @@ export const ProductCard = props => {
       stepView = false,
       autoPlaySlider = false,
    } = props
-   // console.log('🚀 ~ file: product_card.jsx ~ line 50 ~ data', data)
    const { t, dynamicTrans, locale } = useTranslation()
-   const {noProductImage} = useConfig()
+   const { noProductImage } = useConfig()
    const currentLang = React.useMemo(() => locale, [locale])
    const slideRef = React.useRef()
    const properties = {
@@ -128,100 +125,77 @@ export const ProductCard = props => {
          }
       }
    }, [])
+
    return (
       <>
          {showProductCard && (
             <div className={classNames('hern-product-card', className)}>
                {showImage && (
                   <div className="hern-product-card-image-container">
-                     <Slide
-                        ref={slideRef}
-                        infinite={autoPlaySlider}
-                        autoplay={autoPlaySlider}
-                        {...properties}
-                     >
-                        {data.assets.images.map((each, index) => {
-
-                           // each = noProductImage
-                           // console.log("abcde",noProductImage)
-                           console.log("EACH",each)
-                           if (each === undefined || each === null)
-                              {
-                                 return (
-                              <div key={each}>
-                                 
-                                 <HernLazyImage
-                                    // src={each}
-                                    dataSrc={noProductImage}
-                                    alt={data.name}
-                                    className={classNames(
-                                       'hern-product-card__image',
-                                       {
-                                          'hern-product-card__image--aspect-ratio':
-                                             maintainRatio,
-                                       }
-                                    )}
-                                    onClick={e => {
-                                       if (onImageClick) {
-                                          e.stopPropagation()
-                                          onImageClick()
-                                       }
-                                    }}
-                                    style={{
-                                       cursor: onImageClick ? 'pointer' : null,
-                                    }}
-                                    width={productImageSize.width}
-                                    height={productImageSize.height}
-                                 />
-                              </div>
-                           )
-                              }
-                           else {
-                              console.log("jjjjj")
+                     {!isEmpty(data.assets.images) ? (
+                        <Slide
+                           ref={slideRef}
+                           infinite={autoPlaySlider}
+                           autoplay={autoPlaySlider}
+                           {...properties}
+                        >
+                           {data.assets.images.map((each, index) => {
                               return (
-                              <div key={each}>
-                                 {/* <div
-                                    className={classNames(
-                                       'lazyload hern-product-card-image-background',
-                                       {
-                                          'hern-product-card-image-background--aspect-ratio':
-                                             maintainRatio,
-                                       }
-                                    )}
-                                    // style={{
-                                    //    backgroundImage: `url(https://dailykit-502-chefbaskit1.s3.us-east-2.amazonaws.com/images/64330-Lal-Maas.jpg)`,
-                                    // }}
-                                    data-bg={each}
-                                 ></div> */}
-                                 
-                                 <HernLazyImage
-                                    // src={each}
-                                    dataSrc={each}
-                                    alt={data.name}
-                                    className={classNames(
-                                       'hern-product-card__image',
-                                       {
-                                          'hern-product-card__image--aspect-ratio':
-                                             maintainRatio,
-                                       }
-                                    )}
-                                    onClick={e => {
-                                       if (onImageClick) {
-                                          e.stopPropagation()
-                                          onImageClick()
-                                       }
-                                    }}
-                                    style={{
-                                       cursor: onImageClick ? 'pointer' : null,
-                                    }}
-                                    width={productImageSize.width}
-                                    height={productImageSize.height}
-                                 />
-                              </div>
-                           )
-                           }
-                        })}
-                     </Slide>
+                                 <div key={each.id}>
+                                    <HernLazyImage
+                                       dataSrc={each}
+                                       alt={data.name}
+                                       className={classNames(
+                                          'hern-product-card__image',
+                                          {
+                                             'hern-product-card__image--aspect-ratio':
+                                                maintainRatio,
+                                          }
+                                       )}
+                                       onClick={e => {
+                                          if (onImageClick) {
+                                             e.stopPropagation()
+                                             onImageClick()
+                                          }
+                                       }}
+                                       style={{
+                                          cursor: onImageClick
+                                             ? 'pointer'
+                                             : null,
+                                       }}
+                                       width={productImageSize.width}
+                                       height={productImageSize.height}
+                                    />
+                                 </div>
+                              )
+                           })}
+                        </Slide>
+                     ) : (
+                        <div>
+                           <HernLazyImage
+                              dataSrc={noProductImage}
+                              alt={data.name}
+                              className={classNames(
+                                 'hern-product-card__image',
+                                 {
+                                    'hern-product-card__image--aspect-ratio':
+                                       maintainRatio,
+                                 }
+                              )}
+                              onClick={e => {
+                                 if (onImageClick) {
+                                    e.stopPropagation()
+                                    onImageClick()
+                                 }
+                              }}
+                              style={{
+                                 cursor: onImageClick ? 'pointer' : null,
+                              }}
+                              width={productImageSize.width}
+                              height={productImageSize.height}
+                           />
+                        </div>
+                     )}
                      {IconOnImage && (
                         <div
                            className="hern-product-card-on-image-icon"

--- a/store/src/sections/featuredCollection/index.js
+++ b/store/src/sections/featuredCollection/index.js
@@ -342,8 +342,7 @@ const ProductWithIntersection = ({
                }
                data={eachProduct}
                showImage={
-                  (config?.informationVisibility?.product?.showImage?.value &&
-                     eachProduct.assets.images.length > 0) ??
+                  config?.informationVisibility?.product?.showImage?.value ??
                   true
                }
                canSwipe={

--- a/store/src/sections/order/index.js
+++ b/store/src/sections/order/index.js
@@ -288,6 +288,19 @@ const ProductWithIntersection = ({
    CustomAreaWrapper,
    autoPlaySlider,
 }) => {
+   // console.log('ABC', eachProduct.assets.images[0])
+   // console.log('BCD', eachProduct.assets)
+   // console.log(
+   //    eachProduct.assets.images[0] == undefined ||
+   //       eachProduct.assets.images[0] === null
+   // )
+   if (
+      eachProduct.assets.images[0] === undefined ||
+      eachProduct.assets.images[0] === null
+   ) {
+      eachProduct.assets.images[0] =
+         'https://d3i0trfokco6a2.cloudfront.net/TPO-396.png'
+   }
    const router = useRouter()
    const productRef = React.useRef()
    const { entry, isIntersected } = useIntersectionObserver(productRef, {

--- a/store/src/sections/order/index.js
+++ b/store/src/sections/order/index.js
@@ -253,6 +253,8 @@ export const OnDemandOrder = ({ config }) => {
                            </div>
                            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                               {eachCategory.products.map(eachProduct => (
+                                 // console.log("Each",eachProduct)
+
                                  <ProductWithIntersection
                                     key={eachProduct.id}
                                     eachProduct={eachProduct}
@@ -288,19 +290,6 @@ const ProductWithIntersection = ({
    CustomAreaWrapper,
    autoPlaySlider,
 }) => {
-   // console.log('ABC', eachProduct.assets.images[0])
-   // console.log('BCD', eachProduct.assets)
-   // console.log(
-   //    eachProduct.assets.images[0] == undefined ||
-   //       eachProduct.assets.images[0] === null
-   // )
-   if (
-      eachProduct.assets.images[0] === undefined ||
-      eachProduct.assets.images[0] === null
-   ) {
-      eachProduct.assets.images[0] =
-         'https://d3i0trfokco6a2.cloudfront.net/TPO-396.png'
-   }
    const router = useRouter()
    const productRef = React.useRef()
    const { entry, isIntersected } = useIntersectionObserver(productRef, {

--- a/store/src/sections/order/index.js
+++ b/store/src/sections/order/index.js
@@ -337,9 +337,9 @@ const ProductWithIntersection = ({
                   }}
                   data={eachProduct}
                   showProductDescription={true}
-                  showImage={
-                     eachProduct.assets.images.length > 0 ? true : false
-                  }
+                  // showImage={
+                  //    eachProduct.assets.images.length > 0 ? true : false
+                  // }
                   customAreaComponent={CustomAreaWrapper}
                   showModifier={
                      productModifier && productModifier.id === eachProduct.id

--- a/store/src/sections/product-gallery/index.js
+++ b/store/src/sections/product-gallery/index.js
@@ -165,7 +165,7 @@ const ProductGrid = ({ config, product, index }) => {
          onImageClick={() => router.push(getRoute('/products/' + product.id))}
          key={index}
          data={product}
-         showImage={product.assets.images.length > 0 ? true : false}
+         //showImage={product.assets.images.length > 0 ? true : false}
          customAreaComponent={
             (!config?.informationVisibility?.showAddButtonInProduct &&
                CustomAreaWrapper) ||


### PR DESCRIPTION
## Description
Assigned a default image for product with no image.
Fixed Visibility of Slide-Arrows

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Changes and Fixes
- A default product image will appear whenever image is not provided for a certain product.
- Slide arrows for switching between multiple images of a product will not appear if product contain single image.

## Screenshots 
<img width="910" alt="image" src="https://user-images.githubusercontent.com/68808342/179931310-7d9943a0-9881-4175-a0df-6f9c7b634980.png">
<img width="911" alt="image" src="https://user-images.githubusercontent.com/68808342/179932494-f811dee2-27f4-48ca-918c-a33206c87d3b.png">



## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Looks good on large screens
- [x] Looks good on mobiles


Affected Apps
- [x] Store
    - [x] Order 
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
