### PR TITLE
fix: auto scroll issue inside menu category | kiosk

### DIFF
--- a/store/src/components/kiosk/menu.js
+++ b/store/src/components/kiosk/menu.js
@@ -83,6 +83,7 @@ const KioskMenu = props => {
    const { cart } = cartState
    const { isStoreAvailable } = useConfig()
    const sidebarRef = React.useRef()
+   const [previousSelectedCategory, setPreviousSelectedCategory] = React.useState(-1)
 
    const scroll = scrollOffset => {
       sidebarRef.current.scrollTop += scrollOffset
@@ -111,6 +112,34 @@ const KioskMenu = props => {
       setSelectedCategory(e.key)
       // changeCategory(e.key)
    }
+   useEffect( ()=> {
+
+      let isReverseScroll = false
+
+      if(previousSelectedCategory >= 0){
+         if(previousSelectedCategory >= selectedCategory){
+            isReverseScroll = true
+         }  else {
+            isReverseScroll = false
+         }
+      }
+      setPreviousSelectedCategory(selectedCategory)
+      const allDivs = document.querySelectorAll(".hern-kiosk__menu-page-product-category")
+      if(selectedCategory >= 2){
+
+         if(isReverseScroll && (selectedCategory == 3 || selectedCategory == 2) ){
+            sidebarRef.current.scroll({
+               top: allDivs[selectedCategory].scrollHeight*(selectedCategory-1) -200,
+               behavior: "smooth",
+            }) 
+         } else {
+            sidebarRef.current.scroll({
+               top: allDivs[selectedCategory].scrollHeight*(selectedCategory-2),
+               behavior: "smooth",
+            })
+         }
+      }
+   }, [selectedCategory])
    useEffect(() => {
       const languageTags = document.querySelectorAll(
          '[data-translation="true"]'


### PR DESCRIPTION
## Description
fixed auto scroll issue -  while scrolling the right menu category left menu category should self-scroll to make selected category in the left-scroll visible 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots 
![image](https://user-images.githubusercontent.com/77051687/179944006-078945d7-24be-4471-b80c-9866f40ddf40.png)

(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [x] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
