### PR TITLE
Config based banner showing in menu-category

### DIFF
--- a/store/src/components/kiosk/menu.js
+++ b/store/src/components/kiosk/menu.js
@@ -468,7 +468,6 @@ const MenuProducts = ({ setCurrentPage, eachCategory, config }) => {
    const [currentGroupProducts, setCurrentGroupedProduct] = useState(
       groupedByType[0].products
    )
-
    useEffect(() => {
       setCurrentGroupedProduct(groupedByType[0].products)
    }, [eachCategory])
@@ -500,12 +499,26 @@ const MenuProducts = ({ setCurrentPage, eachCategory, config }) => {
                className="hern-kiosk__menu-category-banner-img"
             />
          ) : (
-            <p
-               className="hern-kiosk__menu-category-name"
-               data-translation="true"
-            >
-               {eachCategory.name}
-            </p>
+            <>
+               {
+                  (config?.menuSettings?.menuCategoryBannerSettings?.variant?.value?.value === "simple") && 
+                  <p
+                     className="hern-kiosk__menu-category-name-simple"
+                     data-translation="true"
+                  >
+                     {eachCategory.name}
+                  </p>
+               }
+               {
+                  (config?.menuSettings?.menuCategoryBannerSettings?.variant?.value?.value === "simple-underline") && 
+                  <p
+                     className="hern-kiosk__menu-category-name-underline"
+                     data-translation="true"
+                  >
+                     {eachCategory.name}
+                  </p>
+               }
+            </>
          )}
          {groupedByType.length > 1 && (
             <div className="hern-kiosk__menu-product-type">

--- a/store/src/components/kiosk/menu.js
+++ b/store/src/components/kiosk/menu.js
@@ -471,7 +471,9 @@ const MenuProducts = ({ setCurrentPage, eachCategory, config }) => {
    useEffect(() => {
       setCurrentGroupedProduct(groupedByType[0].products)
    }, [eachCategory])
-
+   
+   const classNameForMenuCategoryName = 
+         config?.menuSettings?.menuCategoryBannerSettings?.className?.variant?.value?.value || 'simple'
    const [currentGroup, setCurrentGroup] = useState(groupedByType[0].type)
    const onRadioClick = e => {
       setCurrentGroupedProduct(prev => {
@@ -492,34 +494,33 @@ const MenuProducts = ({ setCurrentPage, eachCategory, config }) => {
          key={eachCategory.name}
       >
          {/* <div name={eachCategory.name} ref={menuRef}></div> */}
-         {eachCategory?.bannerImageUrl ? (
-            <HernLazyImage
-               // src={eachCategory?.bannerImageUrl}
-               dataSrc={eachCategory?.bannerImageUrl}
-               className="hern-kiosk__menu-category-banner-img"
-            />
-         ) : (
-            <>
-               {
-                  (config?.menuSettings?.menuCategoryBannerSettings?.variant?.value?.value === "simple") && 
-                  <p
-                     className="hern-kiosk__menu-category-name-simple"
-                     data-translation="true"
-                  >
-                     {eachCategory.name}
-                  </p>
-               }
-               {
-                  (config?.menuSettings?.menuCategoryBannerSettings?.variant?.value?.value === "simple-underline") && 
-                  <p
-                     className="hern-kiosk__menu-category-name-underline"
-                     data-translation="true"
-                  >
-                     {eachCategory.name}
-                  </p>
-               }
-            </>
-         )}
+         {  config?.menuSettings?.menuCategoryBannerSettings?.showBanner?.value ?
+            (
+               <>
+                  {eachCategory?.bannerImageUrl ? (
+                     <HernLazyImage
+                        dataSrc={eachCategory?.bannerImageUrl}
+                        className="hern-kiosk__menu-category-banner-img"
+                     />
+                  ) : (
+                     <p
+                        className={`hern-kiosk__menu-category-name-${classNameForMenuCategoryName}`}
+                        data-translation="true"
+                     >
+                        {eachCategory.name}
+                     </p>
+                  )}
+               </>
+            ) : (
+               <p
+                  className={`hern-kiosk__menu-category-name-${classNameForMenuCategoryName}`}
+                  data-translation="true"
+               >
+                  {eachCategory.name}
+               </p>
+            )
+         }
+         
          {groupedByType.length > 1 && (
             <div className="hern-kiosk__menu-product-type">
                <div className="hern-kiosk__menu-product-type-list">

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -407,10 +407,30 @@
    align-items: center;
    padding: 1em 0;
 }
-.hern-kiosk__menu-category-name {
-   font-size: 1.5em;
-   margin: 0 0 1em 0;
-   font-weight: 500;
+.hern-kiosk__menu-category-name-simple {
+   font-size: 4rem;
+   margin: 1rem 0 0.2rem 0.5rem;
+   font-weight: 600; 
+}
+.hern-kiosk__menu-category-name-underline {
+   font-size: 4rem;
+   margin: 1rem 0 0.2rem 0.5rem;
+   font-weight: 600;
+   position: relative;
+   z-index: 1;
+   box-sizing: border-box;
+   display: inline-block;
+}
+.hern-kiosk__menu-category-name-underline::after {
+   background: #5cb8b2;
+   height: 8px;
+   z-index: -1;
+   position: absolute;
+   left: 0;
+   right: 0;
+   bottom: 30px;
+   content: '';
+   box-sizing: border-box;
 }
 .hern-kiosk__scroll-element:nth-last-child(1) {
    min-height: 100%;

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -412,7 +412,7 @@
    margin: 1rem 0 0.2rem 0.5rem;
    font-weight: 600; 
 }
-.hern-kiosk__menu-category-name-underline {
+.hern-kiosk__menu-category-name-simple-underline {
    font-size: 4rem;
    margin: 1rem 0 0.2rem 0.5rem;
    font-weight: 600;
@@ -421,7 +421,7 @@
    box-sizing: border-box;
    display: inline-block;
 }
-.hern-kiosk__menu-category-name-underline::after {
+.hern-kiosk__menu-category-name-simple-underline::after {
    background: #5cb8b2;
    height: 8px;
    z-index: -1;


### PR DESCRIPTION

## Description
Created 2 variants for showing Category-Menu-Name in menu category inside the kiosk. Variants are 'simple' which is used for herfy and 'simple-underline'  is for tacobell

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [x] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
