### PR TITLE
fix: infinite render of Recent order table

### DIFF
--- a/admin/src/apps/order/views/Orders/index.jsx
+++ b/admin/src/apps/order/views/Orders/index.jsx
@@ -67,7 +67,7 @@ const Orders = () => {
             payload: { limit: 10, offset: 0 },
          })
       }
-   }, [location.pathname])
+   }, [location.pathname, state])
 
    React.useEffect(() => {
       window.addEventListener('hashchange', () => {

--- a/admin/src/shared/components/DashboardTables/Listings/RecentOrder/index.js
+++ b/admin/src/shared/components/DashboardTables/Listings/RecentOrder/index.js
@@ -28,6 +28,7 @@ const RecentOrderTable = () => {
    const { loading: subsLoading, error: subsError } = useSubscription(
       RECENT_ORDERS,
       {
+         skip: !brandContext,
          variables: {
             where: {
                cart: {
@@ -75,11 +76,10 @@ const RecentOrderTable = () => {
                return newOrder
             })
             setRecentOrders(newData)
-            setStatus({ ...status, loading: false })
+            setStatus({ loading: false })
          },
       }
    )
-   // console.log('recent orders', recentOrders)
    const tableHeaderOnClick = () => {
       history.push('order')
    }
@@ -103,15 +103,16 @@ const RecentOrderTable = () => {
       },
    ]
 
-   if (subsLoading || status.loading) {
-      return <InlineLoader />
-   }
    if (subsError) {
       logger(subsError)
       toast.error('Could not get the Insight data')
+      console.error('suberror-->', subsError)
       return (
          <ErrorState height="320px" message="Could not get the Insight data" />
       )
+   }
+   if (subsLoading || status.loading) {
+      return <InlineLoader />
    }
    if (recentOrders.length == 0) {
       return <Filler message="No Recent Order Data Available" />

--- a/admin/src/shared/components/DashboardTables/graphql/subscription.js
+++ b/admin/src/shared/components/DashboardTables/graphql/subscription.js
@@ -10,6 +10,7 @@ export const RECENT_ORDERS = gql`
          id
          created_at
          cart {
+            id
             status
             customerInfo
          }


### PR DESCRIPTION
## Description
Recent Order table was rendering infinitely at home page when shifted to home page from orders tab.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes and Fixes
- added id column in query

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

Affected Apps
- [ ] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [x] Home
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
