### PR TITLE
Promotional screen after dine in or take out

### DIFF
--- a/store/src/components/kiosk/component/progressBar.js
+++ b/store/src/components/kiosk/component/progressBar.js
@@ -19,7 +19,7 @@ const { Step } = Steps
 export const ProgressBar = props => {
    const { config, setCurrentPage } = props
 
-   const { cartState, dineInTableInfo, setDineInTableInfo } =
+   const { cartState, dineInTableInfo, setDineInTableInfo, storedCartId } =
       React.useContext(CartContext)
    const { t, direction } = useTranslation()
    const { formatMessage } = useIntl()

--- a/store/src/components/kiosk/fulfillment.js
+++ b/store/src/components/kiosk/fulfillment.js
@@ -107,7 +107,8 @@ export const FulfillmentSection = props => {
          })
       }
    }, [kioskRecurrences])
-   const showPromotionalScreen = true
+   const showPromotionalScreen =
+      config?.promotionalScreenSettings?.showPromotionalScreen?.value ?? false
    React.useEffect(() => {
       const languageTags = document.querySelectorAll(
          '[data-translation="true"]'
@@ -481,6 +482,18 @@ const FulfillmentOptionCustom = props => {
    )
 }
 const PromotionalScreen = ({ config, visible, setVisible, setCurrentPage }) => {
+   const { t } = useTranslation()
+   //Config for promotional screen
+   const promotionalScreenSettings = {
+      continueButtonLabel:
+         config?.promotionalScreenSettings?.promotionalScreenContinueButton
+            ?.labelForContinueButton?.value || 'CONTINUE',
+      image:
+         config?.promotionalScreenSettings?.promotionalScreenBackgroundImage
+            ?.value ||
+         'https://dailykit-133-test.s3.us-east-2.amazonaws.com/images/08345-app_promotion.png',
+   }
+   const { image, continueButtonLabel } = promotionalScreenSettings
    return (
       <StyledPromotionalScreen
          title={null}
@@ -492,7 +505,7 @@ const PromotionalScreen = ({ config, visible, setVisible, setCurrentPage }) => {
          closable={false}
       >
          <div tw="h-full relative">
-            <img src="https://dailykit-133-test.s3.us-east-2.amazonaws.com/images/08345-app_promotion.png" />
+            <img src={image} />
             <div tw="absolute bottom-20 w-full flex justify-center">
                <button
                   onClick={() => {
@@ -501,7 +514,7 @@ const PromotionalScreen = ({ config, visible, setVisible, setCurrentPage }) => {
                   }}
                   tw="bg-[#3d0347] text-7xl text-white font-extrabold px-[56px] py-7 tracking-wide"
                >
-                  VIEW MENU
+                  {t(continueButtonLabel)}
                </button>
             </div>
          </div>

--- a/store/src/components/kiosk/fulfillment.js
+++ b/store/src/components/kiosk/fulfillment.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Button } from 'antd'
+import { Button, Drawer } from 'antd'
 import { useCart, useTranslation } from '../../context'
 import { DineInIcon, TakeOutIcon } from '../../assets/icons'
 import { useConfig } from '../../lib'
@@ -7,6 +7,7 @@ import moment from 'moment'
 import { get_env, isDateValidInRRule, isClient } from '../../utils'
 import { DineInTableSelection, PhoneNumberTunnel } from './component'
 import tw from 'twin.macro'
+import styled from 'styled-components'
 
 export const FulfillmentSection = props => {
    const { config, setCurrentPage } = props
@@ -22,6 +23,8 @@ export const FulfillmentSection = props => {
    const [showDineInTableSelection, setShowDineInTableSelection] =
       useState(false)
    const [visible, setVisible] = useState(false)
+   const [isPromotionalScreenVisible, setIsPromotionalScreenVisible] =
+      useState(false)
    React.useEffect(() => {
       // check is there any recurrence available or not
       // if available then check that store is available for current day and time
@@ -104,7 +107,7 @@ export const FulfillmentSection = props => {
          })
       }
    }, [kioskRecurrences])
-
+   const showPromotionalScreen = true
    React.useEffect(() => {
       const languageTags = document.querySelectorAll(
          '[data-translation="true"]'
@@ -135,7 +138,11 @@ export const FulfillmentSection = props => {
          ),
       })
       setShowDineInTableSelection(false)
-      setCurrentPage('menuPage')
+      if (showPromotionalScreen) {
+         setIsPromotionalScreenVisible(true)
+      } else {
+         setCurrentPage('menuPage')
+      }
    }
    return (
       <div
@@ -236,6 +243,10 @@ export const FulfillmentSection = props => {
                               setShowDineInTableSelection
                            }
                            setVisible={setVisible}
+                           setIsPromotionalScreenVisible={
+                              setIsPromotionalScreenVisible
+                           }
+                           showPromotionalScreen
                         />
                      )
                   }
@@ -285,6 +296,12 @@ export const FulfillmentSection = props => {
             visible={visible}
             setVisible={setVisible}
             setCurrentPage={setCurrentPage}
+         />
+         <PromotionalScreen
+            config={config}
+            setCurrentPage={setCurrentPage}
+            visible={isPromotionalScreenVisible}
+            setVisible={setIsPromotionalScreenVisible}
          />
       </div>
    )
@@ -366,6 +383,8 @@ const FulfillmentOptionCustom = props => {
       fulfillment,
       setShowDineInTableSelection,
       setVisible,
+      setIsPromotionalScreenVisible,
+      showPromotionalScreen,
    } = props
 
    const { dispatch, kioskAvailability } = useConfig()
@@ -406,7 +425,11 @@ const FulfillmentOptionCustom = props => {
             !askedPhoneNumber ||
             (askedPhoneNumber && isClient && localStorage.getItem('phone'))
          ) {
-            setCurrentPage('menuPage')
+            if (showPromotionalScreen) {
+               setIsPromotionalScreenVisible(true)
+            } else {
+               setCurrentPage('menuPage')
+            }
          }
       }
       isClient &&
@@ -457,3 +480,36 @@ const FulfillmentOptionCustom = props => {
       </div>
    )
 }
+const PromotionalScreen = ({ config, visible, setVisible, setCurrentPage }) => {
+   return (
+      <StyledPromotionalScreen
+         title={null}
+         placement={'right'}
+         width={'100%'}
+         onClose={() => setVisible(false)}
+         visible={visible}
+         style={{ zIndex: '99999' }}
+         closable={false}
+      >
+         <div tw="h-full relative">
+            <img src="https://dailykit-133-test.s3.us-east-2.amazonaws.com/images/08345-app_promotion.png" />
+            <div tw="absolute bottom-20 w-full flex justify-center">
+               <button
+                  onClick={() => {
+                     setVisible(false)
+                     setCurrentPage('menuPage')
+                  }}
+                  tw="bg-[#3d0347] text-7xl text-white font-extrabold px-[56px] py-7 tracking-wide"
+               >
+                  VIEW MENU
+               </button>
+            </div>
+         </div>
+      </StyledPromotionalScreen>
+   )
+}
+const StyledPromotionalScreen = styled(Drawer)`
+   .ant-drawer-body {
+      padding: 0;
+   }
+`


### PR DESCRIPTION
## Description
- Added a promotional screen after Dine In or Take Out 
- Fix stored cart id not defined error 
#1188 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Changes and Fixes
- Added a promotional screen after Dine In or Take Out 

## Screenshots 
<img width="324" alt="image" src="https://user-images.githubusercontent.com/43314398/180933664-82aeaa09-c9a8-45bd-ba43-a7ab532b24c9.png">


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

Affected Apps
- [x] Store
    - [x] Kiosk
