### PR TITLE
fix: added config based subtotal price for cart item with cart icon

### DIFF
--- a/store/src/components/kiosk/menu.js
+++ b/store/src/components/kiosk/menu.js
@@ -327,17 +327,42 @@ const KioskMenu = props => {
                         >
                            {config?.menuSettings?.cartButton?.variant?.value
                               ?.value === 'simple' ? (
-                              <CartIcon
-                                 size={25}
-                                 stroke={
-                                    config.kioskSettings.buttonSettings
-                                       .textColor.value
-                                 }
-                                 variant="simple"
-                                 count={
-                                    cart?.cartItems_aggregate?.aggregate?.count
-                                 }
-                              />
+                                 <>
+                                    {(!(config?.menuSettings?.showSubTotalWithCartIcon.value)) &&
+                                       <CartIcon
+                                          size={25}
+                                          stroke={
+                                             config.kioskSettings.buttonSettings
+                                                .textColor.value
+                                          }
+                                          variant="simple"
+                                          count={
+                                             cart?.cartItems_aggregate?.aggregate?.count
+                                          }
+                                       />
+                                    }
+                                    { (config?.menuSettings?.showSubTotalWithCartIcon.value) &&
+                                       <div className='hern-kiosk__menu-header-cart-Icon-div'>
+                                          <CartIcon
+                                             size={25}
+                                             stroke={
+                                                config.kioskSettings.buttonSettings
+                                                   .textColor.value
+                                             }
+                                             variant="simple"
+                                             count={
+                                                cart?.cartItems_aggregate?.aggregate?.count
+                                             }
+                                          />
+                                          <span
+                                             style={{verticalAlign: "middle"}}
+                                          >{`| ${formatCurrency(
+                                             cart?.cartOwnerBilling?.totalToPay
+                                          )}`}</span>
+                                       </div>
+                                    }
+                                 </>
+                              
                            ) : (
                               <KioskButton
                                  customClass="hern-kiosk__goto-cart-btn"
@@ -432,7 +457,7 @@ const KioskMenu = props => {
                                        {cart?.cartItems_aggregate?.aggregate
                                           ?.count === 1
                                           ? t('Item')
-                                          : t('Items')}{' '}
+                                          : t('Items')}{'-'}
                                        {formatCurrency(
                                           cart?.cartOwnerBilling?.totalToPay
                                        )}

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -413,7 +413,11 @@
    display: flex;
    justify-content: center;
 }
-
+.hern-kiosk__menu-header-cart-Icon-div {
+   display: flex;
+   align-items: space-between;
+   height: 100%;
+}
 .hern-kiosk__menu-page-product-category {
    display: flex;
    justify-content: center;


### PR DESCRIPTION


## Description
added config based subtotal price for cart item, show with side of cart Icon in header

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- Description of changes and all fixes in this issue

## Screenshots 
![image](https://user-images.githubusercontent.com/77051687/181193050-6455ffd1-ee2b-410a-9292-141c14304882.png)

(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [x] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
