### PR TITLE
fix: changed confirmation message design while going back from menu 

### DIFF
--- a/store/src/components/kiosk/header.js
+++ b/store/src/components/kiosk/header.js
@@ -7,6 +7,7 @@ import { ReloadIcon, ArrowLeftIconBG } from '../../assets/icons'
 import { isClient } from '../../utils'
 import { useIntl } from 'react-intl'
 import { useConfig } from '../../lib'
+import ReactHtmlParser from 'react-html-parser'
 
 export const KioskHeader = props => {
    const { config } = props
@@ -76,10 +77,6 @@ export const KioskHeader = props => {
             )}
          {currentPage === 'menuPage' && 
             <Modal
-            title={formatMessage({
-               id: (config?.kioskSettings?.removeCartItemGoBackButton?.confirmationTextShown?.value ||
-                     "All the cart items will be cleared. Do you still want to go back?"),
-            })}
             visible={showClearCartWarning}
             centered={true}
             onCancel={() => {
@@ -89,6 +86,17 @@ export const KioskHeader = props => {
             footer={null}
             className="hern-kiosk___header-go-back-confirmation-modal"
          >
+            <div style={{
+               fontWeight: "800",
+               fontSize: "24px",
+               marginBottom: "2rem",
+               textAlign: "center",
+               lineHeight: "28px",
+               marginTop: "1rem",
+            }}>
+               { ReactHtmlParser((config?.kioskSettings?.removeCartItemGoBackButton?.confirmationTextShown?.value ||
+                     "All the cart items will be cleared<br>Do you still want to go back?"))}
+            </div>
             <div
                style={{
                   display: 'flex',

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -98,6 +98,7 @@
    }
 }
 .hern-kiosk___header-go-back-confirmation-modal {
+   width: 60% !important;
    .ant-modal-content {
       padding: 1rem;
       border-radius: 0.5rem;


### PR DESCRIPTION


## Description
Moved text in 2 lines of confirmation while going back from the menu page to fulfillment page, a slight change in the config too

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- Description of changes and all fixes in this issue

## Screenshots 
![image](https://user-images.githubusercontent.com/77051687/181426141-45e47983-6fd0-49b0-a20f-0564500de01e.png)

(prefer all screen sizes images)

## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [x] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [x] Kiosk
- [ ] Admin
    - [ ] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
