### PR TITLE
fix: product names shown incomplete in order app(admin)

### DIFF
--- a/admin/src/apps/order/utils/getRecursiveProducts.js
+++ b/admin/src/apps/order/utils/getRecursiveProducts.js
@@ -32,8 +32,8 @@ const getName = displayName => {
    let name = displayName
       .split('->')
       .pop()
-      .split('-')
-      .pop()
+      // .split('-')
+      // .pop()
       .split('@@AR@@')
       .shift()
       .trim()


### PR DESCRIPTION
## Description
Product names having " - " were shown incomplete (text after ' - ' was shown only)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots 
![image](https://user-images.githubusercontent.com/89663357/181729753-a2207994-a73b-41d8-96a4-2b7ac295c484.png)


## Checklist
- [ ] Database schema is updated
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Looks good on large screens
- [ ] Looks good on mobiles
- [ ] Looks good on Tablets

Affected Apps
- [ ] Store
    - [ ] SEO
    - [ ] Menu
    - [ ] Checkout
    - [ ] Add to Cart logic
    - [ ] Location Logic
    - [ ] Product page
    - [ ] Login
    - [ ] Payment
    - [ ] Kiosk
- [ ] Admin
    - [x] Order
    - [ ] CRM
    - [ ] Product app
    - [ ] Analytics
    - [ ] Settings
    - [ ] Brand
    - [ ] Config Builder
    - [ ] Coupons
    - [ ] Locations
    - [ ] Users
    - [ ] Inventory
- [ ] Server
    - [ ] Payment
    - [ ] Email
    - [ ] SMS
    - [ ] Notifications
    - [ ] Integration
    - [ ] Hasura auth
- [ ] Template Engine
