### PR TITLE
Fix/kiosk issues on fulfilment screen

### DIFF
--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -128,7 +128,7 @@
    top: 0;
    left: 0;
    width: 100%;
-   height: 100%;
+   height: fit-content;
    z-index: 10;
    // filter: blur(6px);
 }

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -128,7 +128,7 @@
    top: 0;
    left: 0;
    width: 100%;
-   height: fit-content;
+   height: 100%;
    z-index: 10;
    // filter: blur(6px);
 }

--- a/store/src/styles/components/kiosk.scss
+++ b/store/src/styles/components/kiosk.scss
@@ -214,6 +214,7 @@
    font-weight: 800;
    z-index: 999;
    font-size: 6rem;
+   margin-top: 40px;
 }
 .hern-kiosk__fulfillment-section-secondary-text {
    font-size: 4em;


### PR DESCRIPTION
## Description
Worked on the following issues in Kiosk:

- "ONLY DIGITAL PAYMENT ACCEPTED" text on fulfilment screen needs to be bigger.
- Increase margin above "HUNGRY?" on fulfilment screen.
- Clicking x on pay at counter modal should only close the modal. This was tested and found that it was working accordingly, need to text further.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes and Fixes
- "ONLY DIGITAL PAYMENT ACCEPTED" text on fulfilment screen needs to be bigger.
- Increase margin above "HUNGRY?" on fulfilment screen.
- Clicking x on pay at counter modal should only close the modal. This was tested and found that it was working accordingly, need to text further.

## Screenshots 
(prefer all screen sizes images)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


Affected Apps
- [x] Store
    - [x] Kiosk

